### PR TITLE
feat: migrate reconcilers from polling to kube-rs Controller runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3344,10 +3344,13 @@ dependencies = [
  "bcrypt",
  "binarylane-client",
  "clap",
+ "k8s-openapi",
+ "kube",
  "rand 0.8.5",
  "reqwest",
  "serde",
  "serde_json",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,6 +266,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-rustls",
  "tonic",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ serde_json = "1"
 tokio = { version = "1", features = ["full"] }
 tokio-rustls = { version = "0.26", default-features = false, features = ["ring", "logging", "tls12"] }
 tonic = { version = "0.13", features = ["tls-webpki-roots"] }
+thiserror = "2"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 chrono = { version = "0.4", features = ["serde"] }

--- a/Tiltfile
+++ b/Tiltfile
@@ -57,20 +57,28 @@ _ed_client_key = str(read_file(".dev/mtls-external-dns-client.key")).strip()
 # Deploy via Helm chart. mTLS is enabled so the deployment gets TLS env vars
 # and volume mounts, but we override the helm-generated cert secrets below
 # with our stable dev certs.
+_cloud_init = str(read_file("dev-cloud-init.sh")).strip()
+_helm_set = [
+    "apiToken=" + binarylane_api_token,
+    "image.repository=" + registry_image,
+    "image.tag=latest",
+    "image.pullPolicy=Always",
+    "imagePullSecrets[0].name=" + registry_pull_secret,
+    "autoscaler.cloudInit=" + _cloud_init,
+    # Skip Helm cert generation — we manage mTLS secrets ourselves above.
+    # mtls.enabled stays true so the deployment gets TLS env vars + volume mounts.
+    "mtls.generate=false",
+]
+_rust_log = os.getenv("RUST_LOG", "")
+if _rust_log:
+    _helm_set.append("extraEnv[0].name=RUST_LOG")
+    _helm_set.append("extraEnv[0].value=" + _rust_log)
+
 controller_manifests = helm(
     "chart",
     name="binarylane-controller",
     namespace="binarylane-system",
-    set=[
-        "apiToken=" + binarylane_api_token,
-        "image.repository=" + registry_image,
-        "image.tag=latest",
-        "image.pullPolicy=Always",
-        "imagePullSecrets[0].name=" + registry_pull_secret,
-        # Skip Helm cert generation — we manage mTLS secrets ourselves above.
-        # mtls.enabled stays true so the deployment gets TLS env vars + volume mounts.
-        "mtls.generate=false",
-    ],
+    set=_helm_set,
     values=["tilt-values.yaml", generated_values],
 )
 k8s_yaml(controller_manifests)

--- a/binarylane-client/src/lib.rs
+++ b/binarylane-client/src/lib.rs
@@ -103,7 +103,7 @@ pub struct ListedSize {
     pub disk: i32,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct ListedRegion {
     pub slug: String,
 }

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -71,6 +71,9 @@ spec:
             - name: TLS_CA_PATH
               value: /etc/binarylane-controller/tls/ca.crt
             {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- if or .Values.autoscaler.enabled .Values.externalDns.enabled }}
           ports:
             {{- if .Values.autoscaler.enabled }}

--- a/chart/templates/role.yaml
+++ b/chart/templates/role.yaml
@@ -8,7 +8,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["get", "create", "update", "patch", "delete"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 {{- range .Values.secretNamespaces }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -73,5 +73,7 @@ tolerations:
     operator: Exists
 affinity: {}
 
+extraEnv: []
+
 podAnnotations: {}
 podLabels: {}

--- a/src/controllers/mod.rs
+++ b/src/controllers/mod.rs
@@ -92,11 +92,23 @@ impl ReconcileContext {
             }
         }
 
+        // Take write lock to serialize refreshes — re-check in case another
+        // task already refreshed while we were waiting for the lock.
+        let mut guard = self.bl_catalog.write().await;
+        if let Some(ref cat) = *guard
+            && cat.fetched_at.elapsed() < Duration::from_secs(300)
+        {
+            return Ok(BlCatalogSnapshot {
+                sizes: cat.sizes.clone(),
+                regions: cat.regions.clone(),
+                images: cat.images.clone(),
+            });
+        }
+
         let sizes = self.bl.list_sizes().await?;
         let regions = self.bl.list_regions().await?;
         let images = self.bl.list_images().await?;
 
-        let mut guard = self.bl_catalog.write().await;
         *guard = Some(BlCatalog {
             sizes: sizes.clone(),
             regions: regions.clone(),

--- a/src/controllers/mod.rs
+++ b/src/controllers/mod.rs
@@ -5,8 +5,13 @@ pub mod node_sync;
 pub mod service;
 
 use std::collections::HashSet;
+use std::sync::Arc;
+use std::time::Duration;
 
 use binarylane_client as binarylane;
+use k8s_openapi::api::core::v1::{Node, Secret};
+use kube::runtime::controller::Action;
+use kube::runtime::reflector::ObjectRef;
 
 pub const FINALIZER: &str = "blc.samcday.com/server-cleanup";
 pub const UNINITIALIZED_TAINT: &str = "node.cloudprovider.kubernetes.io/uninitialized";
@@ -32,6 +37,79 @@ pub struct ReconcileContext {
     pub bl: binarylane::Client,
     pub k8s: kube::Client,
     pub secret_namespace: String,
+    pub bl_catalog: tokio::sync::RwLock<Option<BlCatalog>>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("kube: {0}")]
+    Kube(#[from] kube::Error),
+    #[error("{0}")]
+    Other(#[from] anyhow::Error),
+}
+
+pub fn error_policy<T: kube::Resource>(
+    _obj: Arc<T>,
+    _err: &Error,
+    _ctx: Arc<ReconcileContext>,
+) -> Action {
+    Action::requeue(Duration::from_secs(30))
+}
+
+pub fn secret_to_node_mapper(secret: Secret) -> Option<ObjectRef<Node>> {
+    let name = secret.metadata.name.as_deref()?;
+    let node_name = name
+        .strip_suffix("-node-password")
+        .or_else(|| name.strip_suffix("-user-data"))?;
+    Some(ObjectRef::<Node>::new(node_name))
+}
+
+pub struct BlCatalog {
+    pub sizes: Vec<binarylane::ListedSize>,
+    pub regions: Vec<binarylane::ListedRegion>,
+    pub images: Vec<binarylane::ListedImage>,
+    pub fetched_at: std::time::Instant,
+}
+
+pub struct BlCatalogSnapshot {
+    pub sizes: Vec<binarylane::ListedSize>,
+    pub regions: Vec<binarylane::ListedRegion>,
+    pub images: Vec<binarylane::ListedImage>,
+}
+
+impl ReconcileContext {
+    pub async fn bl_catalog(&self) -> std::result::Result<BlCatalogSnapshot, Error> {
+        {
+            let guard = self.bl_catalog.read().await;
+            if let Some(ref cat) = *guard
+                && cat.fetched_at.elapsed() < Duration::from_secs(300)
+            {
+                return Ok(BlCatalogSnapshot {
+                    sizes: cat.sizes.clone(),
+                    regions: cat.regions.clone(),
+                    images: cat.images.clone(),
+                });
+            }
+        }
+
+        let sizes = self.bl.list_sizes().await?;
+        let regions = self.bl.list_regions().await?;
+        let images = self.bl.list_images().await?;
+
+        let mut guard = self.bl_catalog.write().await;
+        *guard = Some(BlCatalog {
+            sizes: sizes.clone(),
+            regions: regions.clone(),
+            images: images.clone(),
+            fetched_at: std::time::Instant::now(),
+        });
+
+        Ok(BlCatalogSnapshot {
+            sizes,
+            regions,
+            images,
+        })
+    }
 }
 
 /// Default-enabled controllers.

--- a/src/controllers/mod.rs
+++ b/src/controllers/mod.rs
@@ -205,4 +205,24 @@ mod tests {
         assert!(set.contains("node-sync"));
         assert!(set.contains("node-bind"));
     }
+
+    #[test]
+    fn test_secret_to_node_mapper() {
+        let make_secret = |name: &str| Secret {
+            metadata: k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta {
+                name: Some(name.to_string()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let ref_ = secret_to_node_mapper(make_secret("worker-1-node-password")).unwrap();
+        assert_eq!(ref_.name, "worker-1");
+
+        let ref_ = secret_to_node_mapper(make_secret("worker-1-user-data")).unwrap();
+        assert_eq!(ref_.name, "worker-1");
+
+        assert!(secret_to_node_mapper(make_secret("unrelated-secret")).is_none());
+        assert!(secret_to_node_mapper(make_secret("node-password")).is_none());
+    }
 }

--- a/src/controllers/node_bind.rs
+++ b/src/controllers/node_bind.rs
@@ -5,6 +5,7 @@ use kube::api::PatchParams;
 use kube::runtime::controller::Action;
 use kube::{Api, ResourceExt};
 use std::sync::Arc;
+use std::time::Duration;
 use tracing::{error, info, warn};
 
 use super::{ANNOTATION_ADOPT, LABEL_SERVER_ID, ReconcileContext};
@@ -33,15 +34,18 @@ pub async fn reconcile(
         return Ok(Action::await_change());
     }
 
-    if let Err(e) = bind_node(&ctx, &name).await {
-        error!(error = format_args!("{e:#}"), node = %name, "node-bind: binding node");
-        return Err(e.into());
+    match bind_node(&ctx, &name).await {
+        Ok(true) => Ok(Action::await_change()),
+        Ok(false) => Ok(Action::requeue(Duration::from_secs(30))),
+        Err(e) => {
+            error!(error = format_args!("{e:#}"), node = %name, "node-bind: binding node");
+            Err(e.into())
+        }
     }
-
-    Ok(Action::await_change())
 }
 
-async fn bind_node(ctx: &ReconcileContext, name: &str) -> AnyResult<()> {
+/// Returns `true` if the node was bound, `false` if no server was found yet.
+async fn bind_node(ctx: &ReconcileContext, name: &str) -> AnyResult<bool> {
     let nodes_api: Api<Node> = Api::all(ctx.k8s.clone());
 
     let server = ctx
@@ -52,7 +56,7 @@ async fn bind_node(ctx: &ReconcileContext, name: &str) -> AnyResult<()> {
 
     let Some(server) = server else {
         warn!(node = name, "no BinaryLane server found matching hostname");
-        return Ok(());
+        return Ok(false);
     };
 
     info!(
@@ -83,5 +87,5 @@ async fn bind_node(ctx: &ReconcileContext, name: &str) -> AnyResult<()> {
         .await
         .context("patching node with provider ID")?;
 
-    Ok(())
+    Ok(true)
 }

--- a/src/controllers/node_bind.rs
+++ b/src/controllers/node_bind.rs
@@ -34,7 +34,7 @@ pub async fn reconcile(
     }
 
     if let Err(e) = bind_node(&ctx, &name).await {
-        error!(error = %e, node = %name, "node-bind: binding node");
+        error!(error = format_args!("{e:#}"), node = %name, "node-bind: binding node");
         return Err(e.into());
     }
 

--- a/src/controllers/node_bind.rs
+++ b/src/controllers/node_bind.rs
@@ -1,54 +1,49 @@
-use anyhow::{Context, Result};
+use anyhow::{Context, Result as AnyResult};
 use binarylane_client as binarylane;
 use k8s_openapi::api::core::v1::Node;
-use kube::Api;
 use kube::api::PatchParams;
+use kube::runtime::controller::Action;
+use kube::{Api, ResourceExt};
+use std::sync::Arc;
 use tracing::{error, info, warn};
 
 use super::{ANNOTATION_ADOPT, LABEL_SERVER_ID, ReconcileContext};
 
-pub async fn reconcile(ctx: &ReconcileContext) {
-    let nodes_api: Api<Node> = Api::all(ctx.k8s.clone());
-    let nodes = match nodes_api.list(&Default::default()).await {
-        Ok(list) => list,
-        Err(e) => {
-            error!(error = %e, "node-bind: listing nodes");
-            return;
-        }
-    };
+pub async fn reconcile(
+    node: Arc<Node>,
+    ctx: Arc<ReconcileContext>,
+) -> std::result::Result<Action, super::Error> {
+    let name = node.name_any();
 
-    for node in &nodes {
-        let Some(name) = node.metadata.name.as_deref() else {
-            continue;
-        };
-
-        // Only process nodes with the adopt annotation.
-        let has_adopt = node
-            .metadata
-            .annotations
-            .as_ref()
-            .is_some_and(|a| a.contains_key(ANNOTATION_ADOPT));
-        if !has_adopt {
-            continue;
-        }
-
-        // Skip nodes already bound to a server.
-        let has_server_id = node
-            .metadata
-            .labels
-            .as_ref()
-            .is_some_and(|l| l.contains_key(LABEL_SERVER_ID));
-        if has_server_id {
-            continue;
-        }
-
-        if let Err(e) = bind_node(ctx, &nodes_api, name).await {
-            error!(error = %e, node = name, "node-bind: binding node");
-        }
+    let has_adopt = node
+        .metadata
+        .annotations
+        .as_ref()
+        .is_some_and(|a| a.contains_key(ANNOTATION_ADOPT));
+    if !has_adopt {
+        return Ok(Action::await_change());
     }
+
+    let has_server_id = node
+        .metadata
+        .labels
+        .as_ref()
+        .is_some_and(|l| l.contains_key(LABEL_SERVER_ID));
+    if has_server_id {
+        return Ok(Action::await_change());
+    }
+
+    if let Err(e) = bind_node(&ctx, &name).await {
+        error!(error = %e, node = %name, "node-bind: binding node");
+        return Err(e.into());
+    }
+
+    Ok(Action::await_change())
 }
 
-async fn bind_node(ctx: &ReconcileContext, nodes_api: &Api<Node>, name: &str) -> Result<()> {
+async fn bind_node(ctx: &ReconcileContext, name: &str) -> AnyResult<()> {
+    let nodes_api: Api<Node> = Api::all(ctx.k8s.clone());
+
     let server = ctx
         .bl
         .get_server_by_hostname(name)

--- a/src/controllers/node_deletion.rs
+++ b/src/controllers/node_deletion.rs
@@ -1,65 +1,59 @@
-use anyhow::{Context, Result};
+use anyhow::{Context, Result as AnyResult};
 use binarylane_client as binarylane;
 use k8s_openapi::api::core::v1::{Node, Secret};
-use kube::Api;
 use kube::api::PatchParams;
+use kube::runtime::controller::Action;
+use kube::{Api, ResourceExt};
+use std::sync::Arc;
+use std::time::Duration;
 use tracing::{error, info};
 
 use super::{FINALIZER, ReconcileContext, node_password_secret_name, user_data_secret_name};
 
-pub async fn reconcile(ctx: &ReconcileContext) {
-    let nodes_api: Api<Node> = Api::all(ctx.k8s.clone());
-    let secrets_api: Api<Secret> = Api::namespaced(ctx.k8s.clone(), &ctx.secret_namespace);
-    let nodes = match nodes_api.list(&Default::default()).await {
-        Ok(list) => list,
-        Err(e) => {
-            error!(error = %e, "node-deletion: listing nodes");
-            return;
-        }
-    };
+pub async fn reconcile(
+    node: Arc<Node>,
+    ctx: Arc<ReconcileContext>,
+) -> std::result::Result<Action, super::Error> {
+    let name = node.name_any();
+    let provider_id = node
+        .spec
+        .as_ref()
+        .and_then(|s| s.provider_id.as_deref())
+        .unwrap_or("");
+    let server_id = binarylane::parse_provider_id(provider_id);
 
-    for node in &nodes {
-        let Some(name) = node.metadata.name.as_deref() else {
-            continue;
-        };
-        let provider_id = node
-            .spec
-            .as_ref()
-            .and_then(|s| s.provider_id.as_deref())
-            .unwrap_or("");
-        let server_id = binarylane::parse_provider_id(provider_id);
+    let has_finalizer = node
+        .metadata
+        .finalizers
+        .as_ref()
+        .is_some_and(|f| f.iter().any(|f| f == FINALIZER));
+    let has_provision_labels = node.metadata.labels.as_ref().is_some_and(|l| {
+        l.contains_key(super::LABEL_SIZE)
+            || l.contains_key(super::LABEL_REGION)
+            || l.contains_key(super::LABEL_IMAGE)
+    });
 
-        let has_finalizer = node
-            .metadata
-            .finalizers
-            .as_ref()
-            .is_some_and(|f| f.iter().any(|f| f == FINALIZER));
-
-        // Process nodes that either have a BL provider ID, have our finalizer,
-        // or are provision candidates.
-        let has_provision_labels = node.metadata.labels.as_ref().is_some_and(|l| {
-            l.contains_key(super::LABEL_SIZE)
-                || l.contains_key(super::LABEL_REGION)
-                || l.contains_key(super::LABEL_IMAGE)
-        });
-        if server_id.is_none() && !has_finalizer && !has_provision_labels {
-            continue;
-        }
-
-        if let Err(e) = reconcile_node(ctx, &nodes_api, &secrets_api, node, name, server_id).await {
-            error!(error = %e, node = name, ?server_id, "node-deletion: reconciling node");
-        }
+    if server_id.is_none() && !has_finalizer && !has_provision_labels {
+        return Ok(Action::await_change());
     }
+
+    if let Err(e) = reconcile_node(&ctx, &node, &name, server_id).await {
+        error!(error = %e, node = %name, ?server_id, "node-deletion: reconciling node");
+        return Err(e.into());
+    }
+
+    Ok(Action::requeue(Duration::from_secs(300)))
 }
 
 async fn reconcile_node(
     ctx: &ReconcileContext,
-    nodes_api: &Api<Node>,
-    secrets_api: &Api<Secret>,
     node: &Node,
     name: &str,
     server_id: Option<i64>,
-) -> Result<()> {
+) -> AnyResult<()> {
+    let nodes_api: Api<Node> = Api::all(ctx.k8s.clone());
+    let secrets_api: Api<Secret> = Api::namespaced(ctx.k8s.clone(), &ctx.secret_namespace);
+
     let has_finalizer = node
         .metadata
         .finalizers
@@ -78,8 +72,8 @@ async fn reconcile_node(
             ctx.bl.delete_server(sid).await.context("deleting server")?;
         }
 
-        delete_secret_if_exists(secrets_api, &node_password_secret_name(name)).await?;
-        delete_secret_if_exists(secrets_api, &user_data_secret_name(name)).await?;
+        delete_secret_if_exists(&secrets_api, &node_password_secret_name(name)).await?;
+        delete_secret_if_exists(&secrets_api, &user_data_secret_name(name)).await?;
 
         let patch = serde_json::json!({
             "metadata": {
@@ -108,8 +102,8 @@ async fn reconcile_node(
                 server_id = sid,
                 "server deleted, removing node"
             );
-            delete_secret_if_exists(secrets_api, &node_password_secret_name(name)).await?;
-            delete_secret_if_exists(secrets_api, &user_data_secret_name(name)).await?;
+            delete_secret_if_exists(&secrets_api, &node_password_secret_name(name)).await?;
+            delete_secret_if_exists(&secrets_api, &user_data_secret_name(name)).await?;
             nodes_api
                 .delete(name, &Default::default())
                 .await
@@ -149,19 +143,19 @@ async fn reconcile_node(
     // before the node exists, so we set the ownerRef here on first reconciliation).
     if let Some(node_uid) = &node.metadata.uid {
         tether_secret_to_node(
-            secrets_api,
+            &secrets_api,
             &node_password_secret_name(name),
             name,
             node_uid,
         )
         .await;
-        tether_secret_to_node(secrets_api, &user_data_secret_name(name), name, node_uid).await;
+        tether_secret_to_node(&secrets_api, &user_data_secret_name(name), name, node_uid).await;
     }
 
     Ok(())
 }
 
-async fn delete_secret_if_exists(secrets_api: &Api<Secret>, name: &str) -> Result<()> {
+async fn delete_secret_if_exists(secrets_api: &Api<Secret>, name: &str) -> AnyResult<()> {
     match secrets_api.delete(name, &Default::default()).await {
         Ok(_) => {
             info!(secret = name, "deleted secret");

--- a/src/controllers/node_provision.rs
+++ b/src/controllers/node_provision.rs
@@ -188,7 +188,7 @@ pub async fn reconcile(
     .await
     {
         let msg = format!("server creation failed: {e:#}");
-        error!(error = %e, node = %name, "node-provision: provisioning failed");
+        error!(error = format_args!("{e:#}"), node = %name, "node-provision: provisioning failed");
         emit_event(&ctx.k8s, &name, node_uid, "Warning", "ProvisionError", &msg).await;
         return Err(e.into());
     }

--- a/src/controllers/node_provision.rs
+++ b/src/controllers/node_provision.rs
@@ -1,9 +1,11 @@
-use anyhow::{Context, Result};
+use anyhow::{Context, Result as AnyResult};
 use binarylane_client as binarylane;
 use k8s_openapi::api::core::v1::{Event, EventSource, Node, ObjectReference, Secret};
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::Time;
-use kube::Api;
 use kube::api::PatchParams;
+use kube::runtime::controller::Action;
+use kube::{Api, ResourceExt};
+use std::sync::Arc;
 use tracing::{error, info, warn};
 
 use super::{
@@ -27,211 +29,172 @@ fn config_hash(labels: Option<&std::collections::BTreeMap<String, String>>) -> S
         .join("|")
 }
 
-pub async fn reconcile(ctx: &ReconcileContext) {
-    let nodes_api: Api<Node> = Api::all(ctx.k8s.clone());
-    let nodes = match nodes_api.list(&Default::default()).await {
-        Ok(list) => list,
-        Err(e) => {
-            error!(error = %e, "node-provision: listing nodes");
-            return;
-        }
-    };
+pub async fn reconcile(
+    node: Arc<Node>,
+    ctx: Arc<ReconcileContext>,
+) -> std::result::Result<Action, super::Error> {
+    let name = node.name_any();
+    let node_uid = node.metadata.uid.clone();
+    let labels = node.metadata.labels.as_ref();
 
-    let sizes = match ctx.bl.list_sizes().await {
-        Ok(s) => s,
-        Err(e) => {
-            error!(error = %e, "node-provision: listing sizes");
-            return;
-        }
-    };
-    let regions = match ctx.bl.list_regions().await {
-        Ok(r) => r,
-        Err(e) => {
-            error!(error = %e, "node-provision: listing regions");
-            return;
-        }
-    };
-    let images = match ctx.bl.list_images().await {
-        Ok(i) => i,
-        Err(e) => {
-            error!(error = %e, "node-provision: listing images");
-            return;
-        }
-    };
-
-    for node in &nodes {
-        let Some(name) = node.metadata.name.as_deref() else {
-            continue;
-        };
-        let node_uid = node.metadata.uid.clone();
-        let labels = node.metadata.labels.as_ref();
-
-        // Skip nodes already bound to a server.
-        if labels.is_some_and(|l| l.contains_key(LABEL_SERVER_ID)) {
-            continue;
-        }
-
-        // Skip nodes being deleted.
-        if node.metadata.deletion_timestamp.is_some() {
-            continue;
-        }
-
-        // Skip nodes with none of the provision labels.
-        let has_any = labels.is_some_and(|l| {
-            l.contains_key(LABEL_SIZE)
-                || l.contains_key(LABEL_REGION)
-                || l.contains_key(LABEL_IMAGE)
-        });
-        if !has_any {
-            continue;
-        }
-
-        // Skip nodes whose config we've already validated and rejected.
-        let hash = config_hash(labels);
-        let already_failed = node
-            .metadata
-            .annotations
-            .as_ref()
-            .and_then(|a| a.get(ANNOTATION_PROVISION_FAILED))
-            .is_some_and(|v| *v == hash);
-        if already_failed {
-            continue;
-        }
-
-        let size = labels.and_then(|l| l.get(LABEL_SIZE));
-        let region = labels.and_then(|l| l.get(LABEL_REGION));
-        let image = labels.and_then(|l| l.get(LABEL_IMAGE));
-
-        // Validate all three required labels are present.
-        let mut missing = Vec::new();
-        if size.is_none() {
-            missing.push(LABEL_SIZE);
-        }
-        if region.is_none() {
-            missing.push(LABEL_REGION);
-        }
-        if image.is_none() {
-            missing.push(LABEL_IMAGE);
-        }
-        if !missing.is_empty() {
-            let msg = format!("missing required labels: {}", missing.join(", "));
-            set_provision_failed(
-                &nodes_api,
-                &ctx.k8s,
-                name,
-                node_uid,
-                &hash,
-                "InvalidConfig",
-                &msg,
-            )
-            .await;
-            continue;
-        }
-
-        let size = size.unwrap();
-        let region = region.unwrap();
-        let image = image.unwrap();
-
-        // Validate size slug.
-        if !sizes.iter().any(|s| s.slug == *size) {
-            let msg = format!(
-                "unknown size '{}' (available: {})",
-                size,
-                sizes
-                    .iter()
-                    .map(|s| s.slug.as_str())
-                    .collect::<Vec<_>>()
-                    .join(", ")
-            );
-            set_provision_failed(
-                &nodes_api,
-                &ctx.k8s,
-                name,
-                node_uid,
-                &hash,
-                "InvalidConfig",
-                &msg,
-            )
-            .await;
-            continue;
-        }
-
-        // Validate region slug.
-        if !regions.iter().any(|r| r.slug == *region) {
-            let msg = format!(
-                "unknown region '{}' (available: {})",
-                region,
-                regions
-                    .iter()
-                    .map(|r| r.slug.as_str())
-                    .collect::<Vec<_>>()
-                    .join(", ")
-            );
-            set_provision_failed(
-                &nodes_api,
-                &ctx.k8s,
-                name,
-                node_uid,
-                &hash,
-                "InvalidConfig",
-                &msg,
-            )
-            .await;
-            continue;
-        }
-
-        // Validate image slug.
-        if !images
-            .iter()
-            .any(|i| i.slug.as_deref() == Some(image.as_str()))
-        {
-            let msg = format!(
-                "unknown image '{}' (available: {})",
-                image,
-                images
-                    .iter()
-                    .filter_map(|i| i.slug.as_deref())
-                    .collect::<Vec<_>>()
-                    .join(", ")
-            );
-            set_provision_failed(
-                &nodes_api,
-                &ctx.k8s,
-                name,
-                node_uid,
-                &hash,
-                "InvalidConfig",
-                &msg,
-            )
-            .await;
-            continue;
-        }
-
-        match provision_node(
-            ctx,
-            &nodes_api,
-            name,
-            size.clone(),
-            region.clone(),
-            image.clone(),
-            node_uid.clone(),
-        )
-        .await
-        {
-            Ok(()) => {
-                // Clear the failed annotation and condition if they were set
-                // from a previous attempt (e.g. transient API error).
-                clear_provision_failed(&nodes_api, name).await;
-            }
-            Err(e) => {
-                // Don't set the failed-config annotation — transient errors
-                // (API timeouts, rate limits) should be retried on next cycle.
-                let msg = format!("server creation failed: {e:#}");
-                error!(error = %e, node = name, "node-provision: provisioning failed");
-                emit_event(&ctx.k8s, name, node_uid, "Warning", "ProvisionError", &msg).await;
-            }
-        }
+    if labels.is_some_and(|l| l.contains_key(LABEL_SERVER_ID)) {
+        return Ok(Action::await_change());
     }
+
+    if node.metadata.deletion_timestamp.is_some() {
+        return Ok(Action::await_change());
+    }
+
+    let has_any = labels.is_some_and(|l| {
+        l.contains_key(LABEL_SIZE) || l.contains_key(LABEL_REGION) || l.contains_key(LABEL_IMAGE)
+    });
+    if !has_any {
+        return Ok(Action::await_change());
+    }
+
+    let hash = config_hash(labels);
+    let already_failed = node
+        .metadata
+        .annotations
+        .as_ref()
+        .and_then(|a| a.get(ANNOTATION_PROVISION_FAILED))
+        .is_some_and(|v| *v == hash);
+    if already_failed {
+        return Ok(Action::await_change());
+    }
+
+    let nodes_api: Api<Node> = Api::all(ctx.k8s.clone());
+
+    let size = labels.and_then(|l| l.get(LABEL_SIZE));
+    let region = labels.and_then(|l| l.get(LABEL_REGION));
+    let image = labels.and_then(|l| l.get(LABEL_IMAGE));
+
+    let mut missing = Vec::new();
+    if size.is_none() {
+        missing.push(LABEL_SIZE);
+    }
+    if region.is_none() {
+        missing.push(LABEL_REGION);
+    }
+    if image.is_none() {
+        missing.push(LABEL_IMAGE);
+    }
+    if !missing.is_empty() {
+        let msg = format!("missing required labels: {}", missing.join(", "));
+        set_provision_failed(
+            &nodes_api,
+            &ctx.k8s,
+            &name,
+            node_uid,
+            &hash,
+            "InvalidConfig",
+            &msg,
+        )
+        .await;
+        return Ok(Action::await_change());
+    }
+
+    let size = size.cloned().unwrap_or_default();
+    let region = region.cloned().unwrap_or_default();
+    let image = image.cloned().unwrap_or_default();
+
+    let catalog = ctx.bl_catalog().await?;
+
+    if !catalog.sizes.iter().any(|s| s.slug == size) {
+        let msg = format!(
+            "unknown size '{}' (available: {})",
+            size,
+            catalog
+                .sizes
+                .iter()
+                .map(|s| s.slug.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+        set_provision_failed(
+            &nodes_api,
+            &ctx.k8s,
+            &name,
+            node_uid,
+            &hash,
+            "InvalidConfig",
+            &msg,
+        )
+        .await;
+        return Ok(Action::await_change());
+    }
+
+    if !catalog.regions.iter().any(|r| r.slug == region) {
+        let msg = format!(
+            "unknown region '{}' (available: {})",
+            region,
+            catalog
+                .regions
+                .iter()
+                .map(|r| r.slug.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+        set_provision_failed(
+            &nodes_api,
+            &ctx.k8s,
+            &name,
+            node_uid,
+            &hash,
+            "InvalidConfig",
+            &msg,
+        )
+        .await;
+        return Ok(Action::await_change());
+    }
+
+    if !catalog
+        .images
+        .iter()
+        .any(|i| i.slug.as_deref() == Some(image.as_str()))
+    {
+        let msg = format!(
+            "unknown image '{}' (available: {})",
+            image,
+            catalog
+                .images
+                .iter()
+                .filter_map(|i| i.slug.as_deref())
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+        set_provision_failed(
+            &nodes_api,
+            &ctx.k8s,
+            &name,
+            node_uid,
+            &hash,
+            "InvalidConfig",
+            &msg,
+        )
+        .await;
+        return Ok(Action::await_change());
+    }
+
+    if let Err(e) = provision_node(
+        &ctx,
+        &nodes_api,
+        &name,
+        size,
+        region,
+        image,
+        node_uid.clone(),
+    )
+    .await
+    {
+        let msg = format!("server creation failed: {e:#}");
+        error!(error = %e, node = %name, "node-provision: provisioning failed");
+        emit_event(&ctx.k8s, &name, node_uid, "Warning", "ProvisionError", &msg).await;
+        return Err(e.into());
+    }
+
+    clear_provision_failed(&nodes_api, &name).await;
+    Ok(Action::await_change())
 }
 
 async fn set_provision_failed(
@@ -339,7 +302,7 @@ async fn provision_node(
     region: String,
     image: String,
     node_uid: Option<String>,
-) -> Result<()> {
+) -> AnyResult<()> {
     let secrets_api: Api<Secret> = Api::namespaced(ctx.k8s.clone(), &ctx.secret_namespace);
 
     // Ensure finalizer is present before creating any external resources.

--- a/src/controllers/node_sync.rs
+++ b/src/controllers/node_sync.rs
@@ -32,7 +32,7 @@ pub async fn reconcile(
     };
 
     if let Err(e) = reconcile_node(&ctx, &node, &name, server_id).await {
-        error!(error = %e, node = %name, server_id, "node-sync: reconciling node");
+        error!(error = format_args!("{e:#}"), node = %name, server_id, "node-sync: reconciling node");
         return Err(e.into());
     }
 

--- a/src/controllers/node_sync.rs
+++ b/src/controllers/node_sync.rs
@@ -1,52 +1,52 @@
 use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::time::Duration;
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result as AnyResult};
 use binarylane_client as binarylane;
 use k8s_openapi::api::core::v1::Node;
-use kube::Api;
 use kube::api::PatchParams;
+use kube::runtime::controller::Action;
+use kube::{Api, ResourceExt};
 use tracing::{error, info};
 
 use super::{ReconcileContext, UNINITIALIZED_TAINT};
 
-pub async fn reconcile(ctx: &ReconcileContext) {
-    let nodes_api: Api<Node> = Api::all(ctx.k8s.clone());
-    let nodes = match nodes_api.list(&Default::default()).await {
-        Ok(list) => list,
-        Err(e) => {
-            error!(error = %e, "node-sync: listing nodes");
-            return;
-        }
+pub async fn reconcile(
+    node: Arc<Node>,
+    ctx: Arc<ReconcileContext>,
+) -> std::result::Result<Action, super::Error> {
+    let name = node.name_any();
+
+    if node.metadata.deletion_timestamp.is_some() {
+        return Ok(Action::await_change());
+    }
+
+    let provider_id = node
+        .spec
+        .as_ref()
+        .and_then(|s| s.provider_id.as_deref())
+        .unwrap_or("");
+    let Some(server_id) = binarylane::parse_provider_id(provider_id) else {
+        return Ok(Action::await_change());
     };
 
-    for node in &nodes {
-        let Some(name) = node.metadata.name.as_deref() else {
-            continue;
-        };
-        if node.metadata.deletion_timestamp.is_some() {
-            continue;
-        }
-        let provider_id = node
-            .spec
-            .as_ref()
-            .and_then(|s| s.provider_id.as_deref())
-            .unwrap_or("");
-        let Some(server_id) = binarylane::parse_provider_id(provider_id) else {
-            continue;
-        };
-        if let Err(e) = reconcile_node(ctx, &nodes_api, node, name, server_id).await {
-            error!(error = %e, node = name, server_id, "node-sync: reconciling node");
-        }
+    if let Err(e) = reconcile_node(&ctx, &node, &name, server_id).await {
+        error!(error = %e, node = %name, server_id, "node-sync: reconciling node");
+        return Err(e.into());
     }
+
+    Ok(Action::requeue(Duration::from_secs(300)))
 }
 
 async fn reconcile_node(
     ctx: &ReconcileContext,
-    nodes_api: &Api<Node>,
     node: &Node,
     name: &str,
     server_id: i64,
-) -> Result<()> {
+) -> AnyResult<()> {
+    let nodes_api: Api<Node> = Api::all(ctx.k8s.clone());
+
     let server = ctx
         .bl
         .get_server(server_id)

--- a/src/controllers/service.rs
+++ b/src/controllers/service.rs
@@ -1,8 +1,12 @@
-use anyhow::{Context, Result};
+use anyhow::{Context, Result as AnyResult};
 use binarylane_client as binarylane;
 use k8s_openapi::api::core::v1::{Node, Service};
+use kube::ResourceExt;
 use kube::api::PatchParams;
+use kube::runtime::controller::Action;
 use kube::{Api, Client as KubeClient};
+use std::sync::Arc;
+use std::time::Duration;
 use tracing::{error, info, warn};
 
 use super::ReconcileContext;
@@ -11,30 +15,33 @@ const ANNOTATION_LB_ID: &str = "binarylane.com.au/load-balancer-id";
 const ANNOTATION_LB_REGION: &str = "binarylane.com.au/load-balancer-region";
 const FINALIZER: &str = "binarylane.com.au/load-balancer";
 
-pub async fn reconcile(ctx: &ReconcileContext) {
-    let svc_api: Api<Service> = Api::all(ctx.k8s.clone());
-    let services = match svc_api.list(&Default::default()).await {
-        Ok(list) => list,
-        Err(e) => {
-            error!(error = %e, "listing services");
-            return;
+pub async fn reconcile(
+    svc: Arc<Service>,
+    ctx: Arc<ReconcileContext>,
+) -> std::result::Result<Action, super::Error> {
+    let spec = match svc.spec.as_ref() {
+        Some(s) => s,
+        None => return Ok(Action::await_change()),
+    };
+    if spec.type_.as_deref() != Some("LoadBalancer") {
+        return Ok(Action::await_change());
+    }
+
+    let ns = match svc.metadata.namespace.as_deref() {
+        Some(ns) => ns,
+        None => {
+            warn!(service = %svc.name_any(), "service missing namespace, skipping");
+            return Ok(Action::await_change());
         }
     };
+    let name = svc.name_any();
 
-    for svc in &services {
-        let spec = match svc.spec.as_ref() {
-            Some(s) => s,
-            None => continue,
-        };
-        if spec.type_.as_deref() != Some("LoadBalancer") {
-            continue;
-        }
-        let ns = svc.metadata.namespace.as_deref().unwrap_or("default");
-        let name = svc.metadata.name.as_deref().unwrap_or("");
-        if let Err(e) = reconcile_service(&ctx.bl, &ctx.k8s, svc, ns, name).await {
-            error!(error = %e, service = %format!("{ns}/{name}"), "reconciling service");
-        }
+    if let Err(e) = reconcile_service(&ctx.bl, &ctx.k8s, &svc, ns, &name).await {
+        error!(error = %e, service = %format!("{ns}/{name}"), "reconciling service");
+        return Err(e.into());
     }
+
+    Ok(Action::requeue(Duration::from_secs(60)))
 }
 
 async fn reconcile_service(
@@ -43,7 +50,7 @@ async fn reconcile_service(
     svc: &Service,
     ns: &str,
     name: &str,
-) -> Result<()> {
+) -> AnyResult<()> {
     let svc_api: Api<Service> = Api::namespaced(k8s.clone(), ns);
 
     // Handle deletion
@@ -191,7 +198,7 @@ async fn create_load_balancer(
     rules: Vec<binarylane::ForwardingRule>,
     health_check: binarylane::HealthCheck,
     node_ids: Vec<i64>,
-) -> Result<()> {
+) -> AnyResult<()> {
     info!(service = %format!("{ns}/{name}"), region, "creating load balancer");
     let lb = bl
         .create_load_balancer(binarylane::CreateLoadBalancerRequest {
@@ -227,7 +234,7 @@ async fn update_service_status(
     svc_api: &Api<Service>,
     name: &str,
     lb: &binarylane::LoadBalancer,
-) -> Result<()> {
+) -> AnyResult<()> {
     if lb.ip.is_empty() {
         return Ok(());
     }
@@ -256,7 +263,7 @@ async fn handle_deletion(
     svc: &Service,
     ns: &str,
     name: &str,
-) -> Result<()> {
+) -> AnyResult<()> {
     let has_finalizer = svc
         .metadata
         .finalizers
@@ -304,7 +311,7 @@ async fn handle_deletion(
     Ok(())
 }
 
-async fn get_ready_node_server_ids(k8s: &KubeClient) -> Result<Vec<i64>> {
+async fn get_ready_node_server_ids(k8s: &KubeClient) -> AnyResult<Vec<i64>> {
     let nodes_api: Api<Node> = Api::all(k8s.clone());
     let nodes = nodes_api
         .list(&Default::default())

--- a/src/controllers/service.rs
+++ b/src/controllers/service.rs
@@ -37,7 +37,7 @@ pub async fn reconcile(
     let name = svc.name_any();
 
     if let Err(e) = reconcile_service(&ctx.bl, &ctx.k8s, &svc, ns, &name).await {
-        error!(error = %e, service = %format!("{ns}/{name}"), "reconciling service");
+        error!(error = format_args!("{e:#}"), service = %format!("{ns}/{name}"), "reconciling service");
         return Err(e.into());
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -236,9 +236,20 @@ async fn main() -> Result<()> {
         }));
     }
 
-    // Detach controller tasks
+    // Monitor controller tasks — exit if any panic. Clean exits (e.g. from
+    // shutdown_on_signal) are expected and ignored.
     if !handles.is_empty() {
         info!(count = handles.len(), "controllers started");
+        tokio::spawn(async move {
+            let (result, _index, _remaining) = futures::future::select_all(handles).await;
+            match result {
+                Ok(_) => {}
+                Err(e) => {
+                    error!(error = %e, "controller panicked");
+                    std::process::exit(1);
+                }
+            }
+        });
     }
 
     let tls_vars = [&args.tls_cert_path, &args.tls_key_path, &args.tls_ca_path];

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,11 +8,12 @@ pub mod proto {
     tonic::include_proto!("clusterautoscaler.cloudprovider.v1.externalgrpc");
 }
 
-use std::time::Duration;
-
 use anyhow::{Context, Result};
 use clap::Parser;
 use futures::StreamExt;
+use k8s_openapi::api::core::v1::{Node, Secret, Service};
+use kube::Api;
+use kube::runtime::{Controller, watcher};
 use tonic::transport::{Certificate, Identity, Server, ServerTlsConfig};
 use tracing::{error, info, warn};
 
@@ -61,6 +62,29 @@ struct Args {
     controllers: String,
 }
 
+async fn shutdown_signal() {
+    #[cfg(unix)]
+    {
+        match tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()) {
+            Ok(mut sigterm) => {
+                tokio::select! {
+                    _ = tokio::signal::ctrl_c() => {}
+                    _ = sigterm.recv() => {}
+                }
+            }
+            Err(e) => {
+                warn!(error = %e, "failed to install SIGTERM handler; waiting for SIGINT only");
+                let _ = tokio::signal::ctrl_c().await;
+            }
+        }
+    }
+
+    #[cfg(not(unix))]
+    {
+        let _ = tokio::signal::ctrl_c().await;
+    }
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     tracing_subscriber::fmt()
@@ -81,6 +105,7 @@ async fn main() -> Result<()> {
         bl: bl.clone(),
         k8s: k8s.clone(),
         secret_namespace: args.pod_namespace.clone(),
+        bl_catalog: tokio::sync::RwLock::new(None),
     });
 
     let mut handles: Vec<tokio::task::JoinHandle<()>> = Vec::new();
@@ -88,73 +113,132 @@ async fn main() -> Result<()> {
     if enabled.contains("node-sync") {
         let ctx = ctx.clone();
         handles.push(tokio::spawn(async move {
-            info!(interval = ?Duration::from_secs(30), "node-sync controller starting");
-            let mut interval = tokio::time::interval(Duration::from_secs(30));
-            loop {
-                interval.tick().await;
-                controllers::node_sync::reconcile(&ctx).await;
-            }
+            info!("node-sync controller starting");
+            let nodes: Api<Node> = Api::all(ctx.k8s.clone());
+            Controller::new(nodes, watcher::Config::default())
+                .shutdown_on_signal()
+                .run(
+                    controllers::node_sync::reconcile,
+                    controllers::error_policy,
+                    ctx,
+                )
+                .for_each(|res| async move {
+                    match res {
+                        Ok((obj, _)) => tracing::trace!(name = %obj.name, "node-sync: reconciled"),
+                        Err(e) => tracing::warn!(error = %e, "node-sync: reconcile failed"),
+                    }
+                })
+                .await;
         }));
     }
 
     if enabled.contains("node-deletion") {
         let ctx = ctx.clone();
         handles.push(tokio::spawn(async move {
-            info!(interval = ?Duration::from_secs(30), "node-deletion controller starting");
-            let mut interval = tokio::time::interval(Duration::from_secs(30));
-            loop {
-                interval.tick().await;
-                controllers::node_deletion::reconcile(&ctx).await;
-            }
+            info!("node-deletion controller starting");
+            let nodes: Api<Node> = Api::all(ctx.k8s.clone());
+            let secrets: Api<Secret> = Api::namespaced(ctx.k8s.clone(), &ctx.secret_namespace);
+            Controller::new(nodes, watcher::Config::default())
+                .watches(
+                    secrets,
+                    watcher::Config::default(),
+                    controllers::secret_to_node_mapper,
+                )
+                .shutdown_on_signal()
+                .run(
+                    controllers::node_deletion::reconcile,
+                    controllers::error_policy,
+                    ctx,
+                )
+                .for_each(|res| async move {
+                    match res {
+                        Ok((obj, _)) => {
+                            tracing::trace!(name = %obj.name, "node-deletion: reconciled")
+                        }
+                        Err(e) => tracing::warn!(error = %e, "node-deletion: reconcile failed"),
+                    }
+                })
+                .await;
         }));
     }
 
     if enabled.contains("node-bind") {
         let ctx = ctx.clone();
         handles.push(tokio::spawn(async move {
-            info!(interval = ?Duration::from_secs(30), "node-bind controller starting");
-            let mut interval = tokio::time::interval(Duration::from_secs(30));
-            loop {
-                interval.tick().await;
-                controllers::node_bind::reconcile(&ctx).await;
-            }
+            info!("node-bind controller starting");
+            let nodes: Api<Node> = Api::all(ctx.k8s.clone());
+            Controller::new(nodes, watcher::Config::default())
+                .shutdown_on_signal()
+                .run(
+                    controllers::node_bind::reconcile,
+                    controllers::error_policy,
+                    ctx,
+                )
+                .for_each(|res| async move {
+                    match res {
+                        Ok((obj, _)) => tracing::trace!(name = %obj.name, "node-bind: reconciled"),
+                        Err(e) => tracing::warn!(error = %e, "node-bind: reconcile failed"),
+                    }
+                })
+                .await;
         }));
     }
 
     if enabled.contains("node-provision") {
         let ctx = ctx.clone();
         handles.push(tokio::spawn(async move {
-            info!(interval = ?Duration::from_secs(30), "node-provision controller starting");
-            let mut interval = tokio::time::interval(Duration::from_secs(30));
-            loop {
-                interval.tick().await;
-                controllers::node_provision::reconcile(&ctx).await;
-            }
+            info!("node-provision controller starting");
+            let nodes: Api<Node> = Api::all(ctx.k8s.clone());
+            let secrets: Api<Secret> = Api::namespaced(ctx.k8s.clone(), &ctx.secret_namespace);
+            Controller::new(nodes, watcher::Config::default())
+                .watches(
+                    secrets,
+                    watcher::Config::default(),
+                    controllers::secret_to_node_mapper,
+                )
+                .shutdown_on_signal()
+                .run(
+                    controllers::node_provision::reconcile,
+                    controllers::error_policy,
+                    ctx,
+                )
+                .for_each(|res| async move {
+                    match res {
+                        Ok((obj, _)) => {
+                            tracing::trace!(name = %obj.name, "node-provision: reconciled")
+                        }
+                        Err(e) => tracing::warn!(error = %e, "node-provision: reconcile failed"),
+                    }
+                })
+                .await;
         }));
     }
 
     if enabled.contains("service") {
         let ctx = ctx.clone();
         handles.push(tokio::spawn(async move {
-            info!(interval = ?Duration::from_secs(30), "service controller starting");
-            let mut interval = tokio::time::interval(Duration::from_secs(30));
-            loop {
-                interval.tick().await;
-                controllers::service::reconcile(&ctx).await;
-            }
+            info!("service controller starting");
+            let services: Api<Service> = Api::all(ctx.k8s.clone());
+            Controller::new(services, watcher::Config::default())
+                .shutdown_on_signal()
+                .run(
+                    controllers::service::reconcile,
+                    controllers::error_policy,
+                    ctx,
+                )
+                .for_each(|res| async move {
+                    match res {
+                        Ok((obj, _)) => tracing::trace!(name = %obj.name, "service: reconciled"),
+                        Err(e) => tracing::warn!(error = %e, "service: reconcile failed"),
+                    }
+                })
+                .await;
         }));
     }
 
-    // Monitor controller tasks - exit if any die
+    // Detach controller tasks
     if !handles.is_empty() {
-        tokio::spawn(async move {
-            let (result, _index, _remaining) = futures::future::select_all(handles).await;
-            match result {
-                Ok(_) => error!("controller exited unexpectedly"),
-                Err(e) => error!(error = %e, "controller panicked"),
-            }
-            std::process::exit(1);
-        });
+        info!(count = handles.len(), "controllers started");
     }
 
     let tls_vars = [&args.tls_cert_path, &args.tls_key_path, &args.tls_ca_path];
@@ -203,7 +287,8 @@ async fn main() -> Result<()> {
     }
 
     if !args.cluster_autoscaler_service {
-        std::future::pending::<()>().await;
+        shutdown_signal().await;
+        info!("shutdown signal received");
         return Ok(());
     }
 
@@ -253,7 +338,10 @@ async fn main() -> Result<()> {
 
     server
         .add_service(svc)
-        .serve(addr)
+        .serve_with_shutdown(addr, async {
+            shutdown_signal().await;
+            info!("shutdown signal received");
+        })
         .await
         .context("gRPC server error")?;
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -9,7 +9,10 @@ bcrypt = "0.16"
 binarylane-client = { path = "../binarylane-client" }
 base64 = "0.22"
 clap = { version = "4", features = ["derive", "env"] }
+k8s-openapi = { version = "0.25", features = ["v1_33"] }
+kube = { version = "1", features = ["client", "rustls-tls"], default-features = false }
 rand = "0.8"
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "rustls-tls"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -2,6 +2,7 @@ use std::fs;
 use std::io::{ErrorKind, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
+use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -9,6 +10,10 @@ use anyhow::{Context, Result, bail};
 use base64::Engine;
 use bcrypt::hash;
 use clap::{Args, Parser, Subcommand};
+use k8s_openapi::api::apps::v1::Deployment;
+use k8s_openapi::api::core::v1::{Namespace, Node, Secret, Service, ServiceAccount};
+use kube::api::{Patch, PatchParams};
+use kube::{Api, ResourceExt};
 use rand::distributions::Alphanumeric;
 use rand::{Rng, thread_rng};
 use serde::{Deserialize, Serialize};
@@ -545,40 +550,7 @@ fn cmd_dev_up(mut args: DevUpArgs) -> Result<()> {
         t.elapsed().as_secs_f64()
     );
 
-    let registry_config = RegistryConfig {
-        host: &registry_host,
-        username: &registry_username,
-        password: &registry_password,
-        htpasswd: &registry_htpasswd,
-        secret_name: &args.registry_secret_name,
-    };
-
-    let t = Instant::now();
-    ensure_dev_registry(
-        &server_ip,
-        &ssh_user,
-        Some(&ssh_key_path),
-        &args.known_hosts,
-        &registry_config,
-        timeout,
-    )?;
-    eprintln!(
-        "  registry deployed ....... {:.1}s",
-        t.elapsed().as_secs_f64()
-    );
-
-    let t = Instant::now();
-    wait_for_registry(
-        &registry_host,
-        &registry_username,
-        &registry_password,
-        timeout,
-    )?;
-    eprintln!(
-        "  registry http ready ..... {:.1}s",
-        t.elapsed().as_secs_f64()
-    );
-
+    // -- Last SSH calls: grab kubeconfig + token, then no more SSH --
     let raw_kubeconfig = read_remote_file(
         &server_ip,
         &ssh_user,
@@ -604,13 +576,14 @@ fn cmd_dev_up(mut args: DevUpArgs) -> Result<()> {
     }
 
     let k3s_url = format!("https://{}:6443", server_ip);
-    let kubeconfig = rewrite_kubeconfig_server(&raw_kubeconfig, &k3s_url);
+    let kubeconfig_str = rewrite_kubeconfig_server(&raw_kubeconfig, &k3s_url);
     let registry_image_repo = format!("{}/binarylane-controller", registry_host);
 
-    fs::write(&args.kubeconfig_out, kubeconfig).with_context(|| {
+    let kubeconfig_out_abs = absolute_path(&args.kubeconfig_out)?;
+    fs::write(&kubeconfig_out_abs, &kubeconfig_str).with_context(|| {
         format!(
             "writing local kubeconfig to {}",
-            args.kubeconfig_out.display()
+            kubeconfig_out_abs.display()
         )
     })?;
     write_docker_config(
@@ -621,6 +594,95 @@ fn cmd_dev_up(mut args: DevUpArgs) -> Result<()> {
     )?;
     write_dev_tilt_values(&tilt_values_out)?;
     write_dev_resources(&dev_resources_out, &args, &k3s_url, &k3s_token)?;
+
+    // -- From here: kube-rs only, no more SSH --
+    let t = Instant::now();
+    let rt = tokio::runtime::Runtime::new().context("creating tokio runtime")?;
+    let kube_init_config = Arc::new(KubeInitConfig {
+        registry_host: registry_host.clone(),
+        registry_username: registry_username.clone(),
+        registry_password: registry_password.clone(),
+        registry_htpasswd: registry_htpasswd.clone(),
+        registry_secret_name: args.registry_secret_name.clone(),
+    });
+    rt.block_on(async {
+        let kubeconfig = kube::config::Kubeconfig::read_from(&kubeconfig_out_abs)
+            .context("reading kubeconfig for kube client")?;
+        let config = kube::Config::from_custom_kubeconfig(kubeconfig, &Default::default())
+            .await
+            .context("building kube config")?;
+        let client = kube::Client::try_from(config).context("building kube client")?;
+
+        // Verify API server is reachable before spawning tasks.
+        wait_for_api_server(&client).await?;
+        eprintln!(
+            "  kube api ready .......... {:.1}s",
+            t.elapsed().as_secs_f64()
+        );
+
+        let cfg = kube_init_config.clone();
+        let t_taint = Instant::now();
+        let t_registry = Instant::now();
+
+        let h_taint = tokio::spawn({
+            let client = client.clone();
+            async move {
+                remove_node_taints(&client).await?;
+                eprintln!(
+                    "  taint removed ........... {:.1}s",
+                    t_taint.elapsed().as_secs_f64()
+                );
+                Ok::<(), anyhow::Error>(())
+            }
+        });
+
+        let h_registry = tokio::spawn({
+            let client = client.clone();
+            let cfg = cfg.clone();
+            async move {
+                deploy_registry(&client, &cfg).await?;
+                eprintln!(
+                    "  registry deployed ....... {:.1}s",
+                    t_registry.elapsed().as_secs_f64()
+                );
+                wait_for_registry_http(
+                    &cfg.registry_host,
+                    &cfg.registry_username,
+                    &cfg.registry_password,
+                )
+                .await?;
+                eprintln!(
+                    "  registry http ready ..... {:.1}s",
+                    t_registry.elapsed().as_secs_f64()
+                );
+                Ok::<(), anyhow::Error>(())
+            }
+        });
+
+        let h_secrets = tokio::spawn({
+            let client = client.clone();
+            let cfg = cfg.clone();
+            async move { ensure_pull_secrets(&client, &cfg).await }
+        });
+
+        let h_sa = tokio::spawn({
+            let client = client.clone();
+            let cfg = cfg.clone();
+            async move { patch_service_accounts(&client, &cfg).await }
+        });
+
+        h_taint.await.context("taint task panicked")??;
+        h_registry.await.context("registry task panicked")??;
+        h_secrets.await.context("secrets task panicked")??;
+        h_sa.await.context("sa task panicked")??;
+
+        Ok::<(), anyhow::Error>(())
+    })
+    .context("kube cluster init failed")?;
+    eprintln!(
+        "  cluster init ............ {:.1}s",
+        t.elapsed().as_secs_f64()
+    );
 
     state.server_id = Some(server.id);
     state.server_name = server.name.clone();
@@ -967,12 +1029,12 @@ ${{SUDO}} systemctl is-active --quiet k3s\n",
     }
 }
 
-struct RegistryConfig<'a> {
-    host: &'a str,
-    username: &'a str,
-    password: &'a str,
-    htpasswd: &'a str,
-    secret_name: &'a str,
+struct KubeInitConfig {
+    registry_host: String,
+    registry_username: String,
+    registry_password: String,
+    registry_htpasswd: String,
+    registry_secret_name: String,
 }
 
 struct K3sRegistryConfig<'a> {
@@ -981,200 +1043,244 @@ struct K3sRegistryConfig<'a> {
     password: &'a str,
 }
 
-fn ensure_dev_registry(
-    host: &str,
-    user: &str,
-    ssh_key_path: Option<&Path>,
-    known_hosts: &Path,
-    registry: &RegistryConfig<'_>,
-    timeout: Duration,
-) -> Result<()> {
-    eprintln!(
-        "Deploying authenticated dev registry at http://{}...",
-        registry.host
-    );
-
-    let manifest = format!(
-        r#"apiVersion: v1
-kind: Namespace
-metadata:
-  name: {ns}
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: registry
-  namespace: {ns}
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: registry
-  template:
-    metadata:
-      labels:
-        app: registry
-    spec:
-      tolerations:
-        - key: node.cloudprovider.kubernetes.io/uninitialized
-          effect: NoSchedule
-          operator: Exists
-      containers:
-        - name: registry
-          image: registry:2
-          imagePullPolicy: IfNotPresent
-          env:
-            - name: REGISTRY_AUTH
-              value: htpasswd
-            - name: REGISTRY_AUTH_HTPASSWD_REALM
-              value: dev
-            - name: REGISTRY_AUTH_HTPASSWD_PATH
-              value: /auth/htpasswd
-          ports:
-            - containerPort: 5000
-              name: http
-          volumeMounts:
-            - name: data
-              mountPath: /var/lib/registry
-            - name: auth
-              mountPath: /auth/htpasswd
-              subPath: htpasswd
-          securityContext:
-            runAsUser: 0
-            runAsGroup: 0
-      volumes:
-        - name: data
-          hostPath:
-            path: {registry_data_hostpath}
-            type: DirectoryOrCreate
-        - name: auth
-          secret:
-            secretName: registry-auth
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: registry-auth
-  namespace: {ns}
-type: Opaque
-stringData:
-  htpasswd: |
-{registry_htpasswd}
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: registry
-  namespace: {ns}
-spec:
-  type: NodePort
-  selector:
-    app: registry
-  ports:
-    - name: http
-      port: 5000
-      targetPort: 5000
-      nodePort: 30500
-"#,
-        ns = REGISTRY_NAMESPACE,
-        registry_data_hostpath = REGISTRY_DATA_HOSTPATH,
-        registry_htpasswd = indent_block(registry.htpasswd, 4),
-    );
-
-    let default_sa_patch = format!(
-        r#"{{"imagePullSecrets":[{{"name":"{}"}}]}}"#,
-        registry.secret_name
-    );
-
-    let script = format!(
-        r#"set -eu
-if [ "$(id -u)" -eq 0 ]; then
-  SUDO=""
-else
-  SUDO="sudo"
-fi
-cat <<'EOF_MANIFEST' | ${{SUDO}} kubectl apply -f -
-{manifest}
-EOF_MANIFEST
-for ns in {registry_ns} default binarylane-system; do
-  ${{SUDO}} kubectl get namespace "$ns" >/dev/null 2>&1 || ${{SUDO}} kubectl create namespace "$ns"
-  ${{SUDO}} kubectl -n "$ns" create secret docker-registry {registry_secret_name} \
-    --docker-server={registry_host} \
-    --docker-username={registry_username} \
-    --docker-password={registry_password} \
-    --dry-run=client -o yaml | ${{SUDO}} kubectl apply -f -
-done
-for ns in default; do
-  for _i in $(seq 1 60); do ${{SUDO}} kubectl -n "$ns" get serviceaccount default >/dev/null 2>&1 && break; sleep 1; done
-  ${{SUDO}} kubectl -n "$ns" patch serviceaccount default --type='merge' -p={default_sa_patch} >/dev/null
-done
-${{SUDO}} kubectl -n {registry_ns} rollout status deployment/registry --timeout=300s
-"#,
-        manifest = manifest,
-        registry_ns = REGISTRY_NAMESPACE,
-        registry_secret_name = shell_single_quote(registry.secret_name),
-        registry_host = shell_single_quote(registry.host),
-        registry_username = shell_single_quote(registry.username),
-        registry_password = shell_single_quote(registry.password),
-        default_sa_patch = shell_single_quote(&default_sa_patch),
-    );
-
-    let start = Instant::now();
-    loop {
-        match run_ssh_script(
-            host,
-            user,
-            ssh_key_path,
-            known_hosts,
-            &script,
-            SshOutputMode::Forward,
-        ) {
-            Ok(_) => {
-                eprintln!("Dev registry is configured");
-                return Ok(());
-            }
-            Err(err) => {
-                if start.elapsed() > timeout {
-                    return Err(err).context("timed out deploying dev registry");
+async fn wait_for_api_server(client: &kube::Client) -> Result<()> {
+    let nodes: Api<Node> = Api::all(client.clone());
+    for attempt in 1u32.. {
+        match nodes.list(&Default::default()).await {
+            Ok(_) => return Ok(()),
+            Err(e) => {
+                if attempt > 60 {
+                    bail!("timed out waiting for kube API server: {e:#}");
                 }
-                eprintln!("dev registry not ready yet: {err}");
-                thread::sleep(Duration::from_secs(10));
+                if attempt == 1 || attempt % 5 == 0 {
+                    eprintln!("Waiting for kube API server ({e})...");
+                }
+                tokio::time::sleep(Duration::from_secs(2)).await;
             }
         }
     }
+    unreachable!()
 }
 
-fn wait_for_registry(
+async fn remove_node_taints(client: &kube::Client) -> Result<()> {
+    let nodes: Api<Node> = Api::all(client.clone());
+    let node_list = nodes
+        .list(&Default::default())
+        .await
+        .context("listing nodes")?;
+    for node in &node_list {
+        let name = node.name_any();
+        let taints = node
+            .spec
+            .as_ref()
+            .and_then(|s| s.taints.as_ref())
+            .cloned()
+            .unwrap_or_default();
+        let has_taint = taints
+            .iter()
+            .any(|t| t.key == "node.cloudprovider.kubernetes.io/uninitialized");
+        if !has_taint {
+            continue;
+        }
+        let new_taints: Vec<serde_json::Value> = taints
+            .iter()
+            .filter(|t| t.key != "node.cloudprovider.kubernetes.io/uninitialized")
+            .map(|t| {
+                let mut v = serde_json::json!({
+                    "key": t.key,
+                    "effect": t.effect,
+                });
+                if let Some(val) = &t.value {
+                    v["value"] = serde_json::json!(val);
+                }
+                if let Some(ts) = &t.time_added {
+                    v["timeAdded"] = serde_json::json!(ts.0.to_rfc3339());
+                }
+                v
+            })
+            .collect();
+        // Use strategic merge patch via application/strategic-merge-patch+json.
+        // For taints (merge key: "key"), setting the list replaces it entirely
+        // when using a regular merge patch.
+        let patch = serde_json::json!({ "spec": { "taints": new_taints } });
+        nodes
+            .patch(&name, &PatchParams::default(), &Patch::Merge(&patch))
+            .await
+            .with_context(|| format!("removing taint from node {name}"))?;
+        // Verify
+        let updated = nodes
+            .get(&name)
+            .await
+            .context("re-reading node after taint patch")?;
+        let still_tainted = updated
+            .spec
+            .as_ref()
+            .and_then(|s| s.taints.as_ref())
+            .is_some_and(|t| {
+                t.iter()
+                    .any(|t| t.key == "node.cloudprovider.kubernetes.io/uninitialized")
+            });
+        if still_tainted {
+            bail!("taint still present on node {name} after patch");
+        }
+        eprintln!("Removed uninitialized taint from node {name}");
+    }
+    Ok(())
+}
+
+async fn deploy_registry(client: &kube::Client, cfg: &KubeInitConfig) -> Result<()> {
+    let pp = PatchParams::apply("xtask").force();
+
+    // Namespace
+    let ns_api: Api<Namespace> = Api::all(client.clone());
+    ns_api
+        .patch(
+            REGISTRY_NAMESPACE,
+            &pp,
+            &Patch::Apply(serde_json::json!({
+                "apiVersion": "v1",
+                "kind": "Namespace",
+                "metadata": { "name": REGISTRY_NAMESPACE }
+            })),
+        )
+        .await
+        .context("applying registry namespace")?;
+
+    // Auth secret
+    let secrets: Api<Secret> = Api::namespaced(client.clone(), REGISTRY_NAMESPACE);
+    secrets
+        .patch(
+            "registry-auth",
+            &pp,
+            &Patch::Apply(serde_json::json!({
+                "apiVersion": "v1",
+                "kind": "Secret",
+                "metadata": { "name": "registry-auth", "namespace": REGISTRY_NAMESPACE },
+                "type": "Opaque",
+                "stringData": { "htpasswd": cfg.registry_htpasswd }
+            })),
+        )
+        .await
+        .context("applying registry auth secret")?;
+
+    // Deployment (no toleration — taint is removed by parallel task)
+    let deploys: Api<Deployment> = Api::namespaced(client.clone(), REGISTRY_NAMESPACE);
+    deploys
+        .patch(
+            "registry",
+            &pp,
+            &Patch::Apply(serde_json::json!({
+                "apiVersion": "apps/v1",
+                "kind": "Deployment",
+                "metadata": { "name": "registry", "namespace": REGISTRY_NAMESPACE },
+                "spec": {
+                    "replicas": 1,
+                    "selector": { "matchLabels": { "app": "registry" } },
+                    "template": {
+                        "metadata": { "labels": { "app": "registry" } },
+                        "spec": {
+                            "containers": [{
+                                "name": "registry",
+                                "image": "registry:2",
+                                "imagePullPolicy": "IfNotPresent",
+                                "env": [
+                                    { "name": "REGISTRY_AUTH", "value": "htpasswd" },
+                                    { "name": "REGISTRY_AUTH_HTPASSWD_REALM", "value": "dev" },
+                                    { "name": "REGISTRY_AUTH_HTPASSWD_PATH", "value": "/auth/htpasswd" },
+                                ],
+                                "ports": [{ "containerPort": 5000, "name": "http" }],
+                                "volumeMounts": [
+                                    { "name": "data", "mountPath": "/var/lib/registry" },
+                                    { "name": "auth", "mountPath": "/auth/htpasswd", "subPath": "htpasswd" },
+                                ],
+                                "securityContext": { "runAsUser": 0, "runAsGroup": 0 },
+                            }],
+                            "volumes": [
+                                { "name": "data", "hostPath": { "path": REGISTRY_DATA_HOSTPATH, "type": "DirectoryOrCreate" } },
+                                { "name": "auth", "secret": { "secretName": "registry-auth" } },
+                            ],
+                        }
+                    }
+                }
+            })),
+        )
+        .await
+        .context("applying registry deployment")?;
+
+    // Service
+    let svcs: Api<Service> = Api::namespaced(client.clone(), REGISTRY_NAMESPACE);
+    svcs.patch(
+        "registry",
+        &pp,
+        &Patch::Apply(serde_json::json!({
+            "apiVersion": "v1",
+            "kind": "Service",
+            "metadata": { "name": "registry", "namespace": REGISTRY_NAMESPACE },
+            "spec": {
+                "type": "NodePort",
+                "selector": { "app": "registry" },
+                "ports": [{
+                    "name": "http",
+                    "port": 5000,
+                    "targetPort": 5000,
+                    "nodePort": 30500,
+                }]
+            }
+        })),
+    )
+    .await
+    .context("applying registry service")?;
+
+    // Wait for rollout
+    for attempt in 1u32.. {
+        let deploy = deploys
+            .get("registry")
+            .await
+            .context("getting registry deployment")?;
+        let status = deploy.status.as_ref();
+        let ready = status.and_then(|s| s.ready_replicas).unwrap_or(0);
+        let replicas = status.and_then(|s| s.replicas).unwrap_or(0);
+        let unavailable = status.and_then(|s| s.unavailable_replicas).unwrap_or(0);
+        if ready >= 1 {
+            return Ok(());
+        }
+        if attempt % 10 == 1 {
+            eprintln!(
+                "Registry rollout: replicas={replicas} ready={ready} unavailable={unavailable} ({attempt}s)"
+            );
+        }
+        if attempt > 300 {
+            bail!("timed out waiting for registry deployment rollout");
+        }
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+    unreachable!()
+}
+
+async fn wait_for_registry_http(
     registry_host: &str,
     registry_username: &str,
     registry_password: &str,
-    timeout: Duration,
 ) -> Result<()> {
     eprintln!(
         "Waiting for registry endpoint http://{}/v2/ ...",
         registry_host
     );
-
-    let client = reqwest::blocking::Client::builder()
+    let http = reqwest::Client::builder()
         .timeout(Duration::from_secs(10))
         .build()
         .context("building HTTP client for registry probe")?;
 
     let start = Instant::now();
     loop {
-        let resp = client
+        let resp = http
             .get(format!("http://{registry_host}/v2/"))
             .basic_auth(registry_username, Some(registry_password))
-            .send();
+            .send()
+            .await;
 
         match resp {
-            Ok(resp) if resp.status().is_success() => {
-                eprintln!(
-                    "Registry endpoint is reachable ({:.0}s)",
-                    start.elapsed().as_secs_f64()
-                );
-                return Ok(());
-            }
+            Ok(resp) if resp.status().is_success() => return Ok(()),
             Ok(resp) => {
                 eprintln!(
                     "Registry probe: status {} ({:.0}s)",
@@ -1191,15 +1297,84 @@ fn wait_for_registry(
             }
         }
 
-        if start.elapsed() > timeout {
+        if start.elapsed() > Duration::from_secs(300) {
             bail!(
                 "timed out waiting for registry endpoint http://{}/v2/",
                 registry_host
             );
         }
-
-        thread::sleep(Duration::from_secs(5));
+        tokio::time::sleep(Duration::from_secs(2)).await;
     }
+}
+
+async fn ensure_pull_secrets(client: &kube::Client, cfg: &KubeInitConfig) -> Result<()> {
+    let docker_config = serde_json::json!({
+        "auths": {
+            &cfg.registry_host: {
+                "username": &cfg.registry_username,
+                "password": &cfg.registry_password,
+            }
+        }
+    });
+    let docker_config_bytes = serde_json::to_vec(&docker_config)?;
+
+    let pp = PatchParams::apply("xtask").force();
+    for ns_name in [REGISTRY_NAMESPACE, "default", "binarylane-system"] {
+        // Ensure namespace
+        let ns_api: Api<Namespace> = Api::all(client.clone());
+        ns_api
+            .patch(
+                ns_name,
+                &pp,
+                &Patch::Apply(serde_json::json!({
+                    "apiVersion": "v1",
+                    "kind": "Namespace",
+                    "metadata": { "name": ns_name }
+                })),
+            )
+            .await
+            .with_context(|| format!("ensuring namespace {ns_name}"))?;
+
+        // Apply docker-registry secret
+        let secrets: Api<Secret> = Api::namespaced(client.clone(), ns_name);
+        secrets
+            .patch(
+                &cfg.registry_secret_name,
+                &pp,
+                &Patch::Apply(serde_json::json!({
+                    "apiVersion": "v1",
+                    "kind": "Secret",
+                    "metadata": { "name": &cfg.registry_secret_name, "namespace": ns_name },
+                    "type": "kubernetes.io/dockerconfigjson",
+                    "data": {
+                        ".dockerconfigjson": base64::engine::general_purpose::STANDARD.encode(&docker_config_bytes),
+                    }
+                })),
+            )
+            .await
+            .with_context(|| format!("applying pull secret in {ns_name}"))?;
+    }
+    Ok(())
+}
+
+async fn patch_service_accounts(client: &kube::Client, cfg: &KubeInitConfig) -> Result<()> {
+    let sa_api: Api<ServiceAccount> = Api::namespaced(client.clone(), "default");
+    // Wait for default SA to exist
+    for attempt in 1u32.. {
+        match sa_api.get("default").await {
+            Ok(_) => break,
+            Err(_) if attempt > 60 => bail!("timed out waiting for default service account"),
+            Err(_) => tokio::time::sleep(Duration::from_secs(1)).await,
+        }
+    }
+    let patch = serde_json::json!({
+        "imagePullSecrets": [{ "name": &cfg.registry_secret_name }]
+    });
+    sa_api
+        .patch("default", &PatchParams::default(), &Patch::Merge(&patch))
+        .await
+        .context("patching default service account")?;
+    Ok(())
 }
 
 fn read_remote_file(
@@ -1662,17 +1837,6 @@ spec:
 
 fn yaml_escape(value: &str) -> String {
     value.replace('\\', "\\\\").replace('"', "\\\"")
-}
-
-fn indent_block(value: &str, spaces: usize) -> String {
-    let prefix = " ".repeat(spaces);
-    let mut out = String::new();
-    for line in value.lines() {
-        out.push_str(&prefix);
-        out.push_str(line);
-        out.push('\n');
-    }
-    out
 }
 
 fn generate_registry_password() -> String {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -545,6 +545,17 @@ fn cmd_dev_up(mut args: DevUpArgs) -> Result<()> {
         t.elapsed().as_secs_f64()
     );
 
+    // Remove the uninitialized taint so pods can schedule before the cloud
+    // controller is running. The taint comes from --kubelet-arg=cloud-provider=external.
+    run_ssh_script(
+        &server_ip,
+        &ssh_user,
+        Some(&ssh_key_path),
+        &args.known_hosts,
+        "k3s kubectl taint nodes --all node.cloudprovider.kubernetes.io/uninitialized:NoSchedule- 2>/dev/null || true",
+        SshOutputMode::Capture,
+    )?;
+
     let registry_config = RegistryConfig {
         host: &registry_host,
         username: &registry_username,
@@ -934,7 +945,7 @@ if ! command -v curl >/dev/null 2>&1; then\n\
   fi\n\
 fi\n\
 if ! command -v k3s >/dev/null 2>&1; then\n\
-  curl -sfL https://get.k3s.io | ${{SUDO}} env INSTALL_K3S_EXEC='server --write-kubeconfig-mode 644 --disable traefik --disable-cloud-controller --tls-san {host}' sh -s -\n\
+  curl -sfL https://get.k3s.io | ${{SUDO}} env INSTALL_K3S_EXEC='server --write-kubeconfig-mode 644 --disable traefik --disable-cloud-controller --kubelet-arg=cloud-provider=external --tls-san {host}' sh -s -\n\
 elif [ \"$k3s_was_active\" -eq 1 ] && [ \"$registries_changed\" -eq 1 ]; then\n\
   ${{SUDO}} systemctl restart k3s\n\
 fi\n\
@@ -1101,6 +1112,7 @@ for ns in {registry_ns} default binarylane-system; do
     --dry-run=client -o yaml | ${{SUDO}} kubectl apply -f -
 done
 for ns in default; do
+  for _i in $(seq 1 60); do ${{SUDO}} kubectl -n "$ns" get serviceaccount default >/dev/null 2>&1 && break; sleep 1; done
   ${{SUDO}} kubectl -n "$ns" patch serviceaccount default --type='merge' -p={default_sa_patch} >/dev/null
 done
 ${{SUDO}} kubectl -n {registry_ns} rollout status deployment/registry --timeout=300s

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1839,6 +1839,17 @@ fn yaml_escape(value: &str) -> String {
     value.replace('\\', "\\\\").replace('"', "\\\"")
 }
 
+fn indent_block(value: &str, spaces: usize) -> String {
+    let prefix = " ".repeat(spaces);
+    let mut out = String::new();
+    for line in value.lines() {
+        out.push_str(&prefix);
+        out.push_str(line);
+        out.push('\n');
+    }
+    out
+}
+
 fn generate_registry_password() -> String {
     thread_rng()
         .sample_iter(Alphanumeric)

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -545,17 +545,6 @@ fn cmd_dev_up(mut args: DevUpArgs) -> Result<()> {
         t.elapsed().as_secs_f64()
     );
 
-    // Remove the uninitialized taint so pods can schedule before the cloud
-    // controller is running. The taint comes from --kubelet-arg=cloud-provider=external.
-    run_ssh_script(
-        &server_ip,
-        &ssh_user,
-        Some(&ssh_key_path),
-        &args.known_hosts,
-        "k3s kubectl taint nodes --all node.cloudprovider.kubernetes.io/uninitialized:NoSchedule- 2>/dev/null || true",
-        SshOutputMode::Capture,
-    )?;
-
     let registry_config = RegistryConfig {
         host: &registry_host,
         username: &registry_username,
@@ -1026,6 +1015,10 @@ spec:
       labels:
         app: registry
     spec:
+      tolerations:
+        - key: node.cloudprovider.kubernetes.io/uninitialized
+          effect: NoSchedule
+          operator: Exists
       containers:
         - name: registry
           image: registry:2


### PR DESCRIPTION
Replace all 5 interval-based polling loops (30s tokio::time::interval + full list() calls) with event-driven kube-rs Controller watchers for sub-second reaction times to K8s resource changes.

- node_bind, node_sync: primary Node watch
- node_deletion, node_provision: primary Node watch + secondary Secret watch
- service: primary Service watch with 60s resync for node membership
- Add shared Error type, error_policy, and secret-to-node mapper
- Add BL API catalog caching (5min TTL) for node_provision
- Add list/watch RBAC verbs for secrets Role