### PR TITLE
feat!: MiniJinja userData + spec.template on AutoScalingGroup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,8 @@ binarylane-client/               REST client crate for BinaryLane v2 API
 - **Labels**: `bl.samcday.com/server-id` (queryable, set after bind/provision), `bl.samcday.com/size`, `bl.samcday.com/region`, `bl.samcday.com/image`.
 - **Associated resources**: Secret `{name}-node-password`, Secret `{name}-user-data`.
 - **Server ownership**: autoscaler identifies managed servers by name prefix (`<namePrefix><groupID>-`).
-- **Cloud-init templating**: simple `{{.Key}}` string replacement with vars from `TMPL_*` env vars plus built-in `NodeName`, `NodeGroup`, `Region`, `Size`.
+- **Cloud-init templating**: `spec.userData` on an `AutoScalingGroup` is a MiniJinja template, rendered per-node at scale-up. Built-in scopes: `node.{name,hostname,index,password}` and `asg.{name,size,region,image,namePrefix,vcpus,memoryMb,diskGb}`. Extra variables come from `spec.templateVariables` as literals or Secret/ConfigMap refs. Strict-undefined: typos in `{{ asg.naem }}` fail scale-up.
+- **Node template**: `spec.template` mirrors `Deployment.spec.template` — `metadata.{labels,annotations}` and `spec.taints` are merged onto every provisioned Node. Reserved keys (hostname, arch, os, the uninitialized taint, etc.) are controller-owned and drop user overrides with a Warning Event. Values flow through both real Node creation and the cluster-autoscaler `NodeGroupTemplateNodeInfo` simulator so scheduling simulation stays honest.
 
 ### Environment variables
 
@@ -64,10 +65,7 @@ binarylane-client/               REST client crate for BinaryLane v2 API
 | `BL_API_TOKEN` | yes | | BinaryLane API token |
 | `CONTROLLERS` | no | `*` | Controller selection (comma-separated) |
 | `NAMESPACE` | no | `binarylane-system` | Target-cluster namespace for per-node Secrets |
-| `CONFIG_PATH` | no | `/etc/binarylane-controller/config.json` | Autoscaler node group config |
-| `CLOUD_INIT_PATH` | no | `/etc/binarylane-controller/cloud-init.sh` | Cloud-init template file |
 | `GRPC_LISTEN_ADDR` | no | `0.0.0.0:8086` | gRPC listen address |
 | `TLS_CERT_PATH` | no | | TLS cert (enables mTLS when all three TLS vars set) |
 | `TLS_KEY_PATH` | no | | TLS private key |
 | `TLS_CA_PATH` | no | | TLS CA certificate |
-| `TMPL_*` | no | | Template variables for cloud-init |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,6 +257,7 @@ dependencies = [
  "k8s-openapi",
  "k8s-pb",
  "kube",
+ "minijinja",
  "prost 0.13.5",
  "prost 0.14.3",
  "prost-types",
@@ -1518,10 +1519,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "memo-map"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38d1115007560874e373613744c6fba374c17688327a71c1476d1a5954cc857b"
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minijinja"
+version = "2.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "805bfd7352166bae857ee569628b52bcd85a1cecf7810861ebceb1686b72b75d"
+dependencies = [
+ "memo-map",
+ "serde",
+]
 
 [[package]]
 name = "mio"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ futures = "0.3"
 k8s-openapi = { version = "0.25", features = ["v1_33"] }
 k8s-pb = "0.9"
 kube = { version = "1", features = ["runtime", "client", "derive", "rustls-tls"], default-features = false }
+minijinja = { version = "2", default-features = false, features = ["builtins", "serde"] }
 prost = "0.13"
 prost-types = "0.13"
 prost_014 = { package = "prost", version = "0.14" }

--- a/README.md
+++ b/README.md
@@ -27,10 +27,66 @@ docker run -e BL_API_TOKEN=<your-token> binarylane-controller
 |---|---|---|---|
 | `BL_API_TOKEN` | yes | | BinaryLane API token |
 | `KUBECONFIG` | no | in-cluster | Path to kubeconfig |
-| `CONFIG_PATH` | no | `/etc/binarylane-controller/config.json` | Autoscaler node group config |
-| `CLOUD_INIT_PATH` | no | `/etc/binarylane-controller/cloud-init.sh` | Cloud-init template file |
+| `NAMESPACE` | no | `binarylane-system` | Target-cluster namespace for per-node Secrets |
 | `GRPC_LISTEN_ADDR` | no | `:8086` | gRPC listen address |
-| `TMPL_*` | no | | Extra variables passed into the cloud-init template |
+
+## AutoScalingGroup templating
+
+An `AutoScalingGroup` declares the shape of Nodes to be provisioned. Two
+templating layers are available:
+
+**`spec.userData`** is a [MiniJinja](https://docs.rs/minijinja) cloud-init
+template, rendered per-node at scale-up time. Built-in variables:
+
+- `node.name`, `node.hostname`, `node.index`, `node.password`
+- `asg.name`, `asg.size`, `asg.region`, `asg.image`, `asg.namePrefix`
+- `asg.vcpus`, `asg.memoryMb`, `asg.diskGb`
+
+Additional variables go under `spec.templateVariables`; each variable is
+either a literal value or a reference to a Secret / ConfigMap key. Values
+are resolved once per scale-up RPC and shared across every Node it creates.
+Because cloud-init only runs at first boot, changing a referenced Secret
+after a Node is provisioned does not re-render the Node's user-data.
+
+**`spec.template`** sets labels, annotations, and taints on every Node
+created by the ASG — mirroring `Deployment.spec.template`. Controller-owned
+keys (for example `kubernetes.io/hostname`, the uninitialized taint) take
+precedence; colliding user values are dropped and surfaced as a Warning
+Event on the ASG.
+
+```yaml
+apiVersion: blc.samcday.com/v1alpha1
+kind: AutoScalingGroup
+metadata:
+  name: gpu-workers
+spec:
+  minSize: 0
+  maxSize: 3
+  size: gpu-1
+  region: syd
+  image: ubuntu-22.04
+  userData: |
+    #cloud-config
+    runcmd:
+      - kubeadm join cp.internal:6443 \
+          --token {{ joinToken }} \
+          --node-name {{ node.name }}
+  templateVariables:
+    - name: joinToken
+      valueFrom:
+        secretKeyRef:
+          name: kubeadm-join-token
+          key: token
+  template:
+    metadata:
+      labels:
+        role: gpu-worker
+    spec:
+      taints:
+        - key: gpu
+          value: "true"
+          effect: NoSchedule
+```
 
 ## Remote dev control plane
 

--- a/Tiltfile
+++ b/Tiltfile
@@ -57,14 +57,12 @@ _ed_client_key = str(read_file(".dev/mtls-external-dns-client.key")).strip()
 # Deploy via Helm chart. mTLS is enabled so the deployment gets TLS env vars
 # and volume mounts, but we override the helm-generated cert secrets below
 # with our stable dev certs.
-_cloud_init = str(read_file("dev-cloud-init.sh")).strip()
 _helm_set = [
     "apiToken=" + binarylane_api_token,
     "image.repository=" + registry_image,
     "image.tag=latest",
     "image.pullPolicy=Always",
     "imagePullSecrets[0].name=" + registry_pull_secret,
-    "autoscaler.cloudInit=" + _cloud_init,
     # Skip Helm cert generation — we manage mTLS secrets ourselves above.
     # mtls.enabled stays true so the deployment gets TLS env vars + volume mounts.
     "mtls.generate=false",

--- a/charts/binarylane-controllers-crds/templates/autoscalinggroups.yaml
+++ b/charts/binarylane-controllers-crds/templates/autoscalinggroups.yaml
@@ -96,23 +96,100 @@ spec:
               size:
                 description: BinaryLane size slug
                 type: string
-              userDataSecretRef:
-                description: Reference to a Secret containing user-data for provisioned nodes
+              template:
+                description: Template applied to Nodes produced by this ASG. Labels/annotations/ taints defined here are merged with controller-owned values at scale-up time; user values that collide with reserved keys are dropped and reported as a Warning Event on the ASG.
                 nullable: true
                 properties:
-                  key:
-                    description: Key within the Secret. Defaults to "user-data" or "password" depending on context.
+                  metadata:
                     nullable: true
-                    type: string
-                  name:
-                    type: string
-                  namespace:
-                    description: Namespace of the Secret. Defaults to the controller's namespace.
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: Annotations to apply to provisioned Nodes.
+                        nullable: true
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: Additional labels to apply to provisioned Nodes. Values that collide with controller-owned labels are dropped.
+                        nullable: true
+                        type: object
+                    type: object
+                  spec:
                     nullable: true
-                    type: string
-                required:
-                - name
+                    properties:
+                      taints:
+                        description: Additional taints to apply to provisioned Nodes. Entries whose key collides with controller-owned taints are dropped.
+                        items:
+                          properties:
+                            effect:
+                              description: 'One of: NoSchedule, PreferNoSchedule, NoExecute.'
+                              type: string
+                            key:
+                              type: string
+                            value:
+                              nullable: true
+                              type: string
+                          required:
+                          - effect
+                          - key
+                          type: object
+                        nullable: true
+                        type: array
+                    type: object
                 type: object
+              templateVariables:
+                description: Variables injected into the `userData` template, in addition to the built-in `node.*` and `asg.*` scopes.
+                items:
+                  properties:
+                    name:
+                      type: string
+                    value:
+                      nullable: true
+                      type: string
+                    valueFrom:
+                      nullable: true
+                      properties:
+                        configMapKeyRef:
+                          nullable: true
+                          properties:
+                            key:
+                              type: string
+                            name:
+                              type: string
+                            namespace:
+                              description: Namespace of the resource. Defaults to the controller's namespace.
+                              nullable: true
+                              type: string
+                          required:
+                          - key
+                          - name
+                          type: object
+                        secretKeyRef:
+                          nullable: true
+                          properties:
+                            key:
+                              type: string
+                            name:
+                              type: string
+                            namespace:
+                              description: Namespace of the resource. Defaults to the controller's namespace.
+                              nullable: true
+                              type: string
+                          required:
+                          - key
+                          - name
+                          type: object
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+              userData:
+                description: 'Cloud-init user-data template (MiniJinja). Rendered per-node at scale-up. Built-in variables: `node.name`, `node.index`, `node.password`, `asg.name`, `asg.size`, `asg.region`, `asg.image`, `asg.namePrefix`, `asg.vcpus`, `asg.memoryMb`, `asg.diskGb`. User variables from `templateVariables` are available at the top level. Templating is evaluated at scale-up time only; Secret/ConfigMap changes do not re-render previously provisioned nodes.'
+                nullable: true
+                type: string
               vcpus:
                 description: Override vCPU count (defaults from BL size catalog if omitted)
                 format: int32

--- a/charts/binarylane-controllers/templates/role.yaml
+++ b/charts/binarylane-controllers/templates/role.yaml
@@ -9,6 +9,11 @@ rules:
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  # AutoScalingGroup templateVariables may reference ConfigMap keys for
+  # non-sensitive values (e.g. API server URL), read at scale-up time.
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get"]
 {{- range .Values.secretNamespaces }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -21,5 +26,8 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["secrets"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
     verbs: ["get"]
 {{- end }}

--- a/dev-cloud-init.sh
+++ b/dev-cloud-init.sh
@@ -16,6 +16,6 @@ if ! command -v curl >/dev/null 2>&1; then
   fi
 fi
 if ! command -v k3s >/dev/null 2>&1; then
-  curl -sfL https://get.k3s.io | ${SUDO} env K3S_URL="{{.K3S_URL}}" K3S_TOKEN="{{.K3S_TOKEN}}" INSTALL_K3S_EXEC="agent --node-name {{.NodeName}} --node-label autoscale-group={{.NodeGroup}}" sh -s -
+  curl -sfL https://get.k3s.io | ${SUDO} env K3S_URL="{{ k3sUrl }}" K3S_TOKEN="{{ k3sToken }}" INSTALL_K3S_EXEC="agent --node-name {{ node.name }} --node-label autoscale-group={{ asg.name }}" sh -s -
 fi
 ${SUDO} systemctl enable --now k3s-agent >/dev/null 2>&1 || true

--- a/src/autoscaler.rs
+++ b/src/autoscaler.rs
@@ -1102,6 +1102,33 @@ mod tests {
     }
 
     #[test]
+    fn server_id_label_is_reserved() {
+        // Regression: node_provision treats a Node with LABEL_SERVER_ID as
+        // already provisioned and exits early. A user sneaking this label
+        // into spec.template would leave the Node permanently stuck.
+        let mut user_labels = BTreeMap::new();
+        user_labels.insert(controllers::LABEL_SERVER_ID.into(), "999".into());
+
+        let mut spec = base_spec();
+        spec.template = Some(NodeTemplate {
+            metadata: Some(NodeTemplateMeta {
+                labels: Some(user_labels),
+                annotations: None,
+            }),
+            spec: None,
+        });
+
+        let attrs = Provider::build_node_labels_and_taints("workers", &spec);
+        assert!(!attrs.labels.contains_key(controllers::LABEL_SERVER_ID));
+        assert!(
+            attrs
+                .dropped
+                .iter()
+                .any(|d| *d == format!("label:{}", controllers::LABEL_SERVER_ID)),
+        );
+    }
+
+    #[test]
     fn reserved_taint_collision_dropped() {
         let mut spec = base_spec();
         spec.template = Some(NodeTemplate {

--- a/src/autoscaler.rs
+++ b/src/autoscaler.rs
@@ -2,9 +2,12 @@ use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 
 use k8s_openapi::api::core::v1::{
-    Node as K8sNode, NodeSpec as K8sNodeSpec, Secret as K8sSecret, Taint as K8sTaint,
+    Event as K8sEvent, EventSource as K8sEventSource, Node as K8sNode, NodeSpec as K8sNodeSpec,
+    ObjectReference as K8sObjectReference, Secret as K8sSecret, Taint as K8sTaint,
 };
-use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta as K8sObjectMeta;
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::{
+    ObjectMeta as K8sObjectMeta, Time as K8sTime,
+};
 use k8s_pb::api::core::v1::{Node, NodeCondition, NodeSpec, NodeStatus, Taint};
 use k8s_pb::apimachinery::pkg::api::resource::Quantity;
 use k8s_pb::apimachinery::pkg::apis::meta::v1::ObjectMeta;
@@ -21,6 +24,7 @@ use crate::proto;
 use binarylane_controller::crd::{
     AutoScalingGroup, AutoScalingGroupSpec, AutoScalingGroupStatus, SecretRef,
 };
+use binarylane_controller::user_data::{self, AsgVars, BuiltinVars, NodeVars};
 
 pub struct Provider {
     k8s: kube::Client,
@@ -28,6 +32,19 @@ pub struct Provider {
     store: Store<AutoScalingGroup>,
     secret_namespace: String,
     size_cache: tokio::sync::Mutex<Option<Vec<binarylane::ListedSize>>>,
+}
+
+struct NodeTaintTuple {
+    key: String,
+    value: Option<String>,
+    effect: String,
+}
+
+struct NodeAttrs {
+    labels: BTreeMap<String, String>,
+    annotations: BTreeMap<String, String>,
+    taints: Vec<NodeTaintTuple>,
+    dropped: Vec<String>,
 }
 
 impl Provider {
@@ -84,9 +101,17 @@ impl Provider {
             .collect())
     }
 
-    fn node_labels(&self, asg_name: &str, spec: &AutoScalingGroupSpec) -> BTreeMap<String, String> {
-        let mut labels = BTreeMap::new();
-        labels.insert("blc.samcday.com/asg".to_string(), asg_name.to_string());
+    /// Build the labels, annotations, and taints applied to a provisioned Node.
+    /// Controller-owned values are set first; user values from `spec.template`
+    /// are merged on top, with collisions against `RESERVED_LABELS` /
+    /// `RESERVED_TAINT_KEYS` dropped. `dropped` holds the dropped keys so the
+    /// caller can emit a Warning Event.
+    ///
+    /// Per-node values (`kubernetes.io/hostname`) are not added here — add
+    /// them after calling this helper.
+    fn build_node_labels_and_taints(asg_name: &str, spec: &AutoScalingGroupSpec) -> NodeAttrs {
+        let mut labels: BTreeMap<String, String> = BTreeMap::new();
+        labels.insert(controllers::LABEL_ASG.to_string(), asg_name.to_string());
         labels.insert(
             "node.kubernetes.io/instance-type".to_string(),
             spec.size.clone(),
@@ -102,7 +127,114 @@ impl Provider {
             "node.kubernetes.io/cloud-provider".to_string(),
             binarylane::PROVIDER_NAME.to_string(),
         );
-        labels
+        labels.insert(controllers::LABEL_SIZE.to_string(), spec.size.clone());
+        labels.insert(controllers::LABEL_REGION.to_string(), spec.region.clone());
+        labels.insert(controllers::LABEL_IMAGE.to_string(), spec.image.clone());
+
+        let mut taints: Vec<NodeTaintTuple> = vec![NodeTaintTuple {
+            key: controllers::UNINITIALIZED_TAINT.to_string(),
+            value: Some("true".to_string()),
+            effect: "NoSchedule".to_string(),
+        }];
+
+        let mut annotations: BTreeMap<String, String> = BTreeMap::new();
+        let mut dropped: Vec<String> = Vec::new();
+
+        if let Some(template) = &spec.template {
+            if let Some(meta) = &template.metadata {
+                if let Some(user_labels) = &meta.labels {
+                    for (k, v) in user_labels {
+                        if controllers::RESERVED_LABELS.contains(&k.as_str()) {
+                            dropped.push(format!("label:{k}"));
+                            continue;
+                        }
+                        labels.insert(k.clone(), v.clone());
+                    }
+                }
+                if let Some(user_annotations) = &meta.annotations {
+                    for (k, v) in user_annotations {
+                        annotations.insert(k.clone(), v.clone());
+                    }
+                }
+            }
+            if let Some(template_spec) = &template.spec
+                && let Some(user_taints) = &template_spec.taints
+            {
+                for t in user_taints {
+                    if controllers::RESERVED_TAINT_KEYS.contains(&t.key.as_str()) {
+                        dropped.push(format!("taint:{}", t.key));
+                        continue;
+                    }
+                    taints.push(NodeTaintTuple {
+                        key: t.key.clone(),
+                        value: t.value.clone(),
+                        effect: t.effect.clone(),
+                    });
+                }
+            }
+        }
+
+        NodeAttrs {
+            labels,
+            annotations,
+            taints,
+            dropped,
+        }
+    }
+
+    /// Resolve vcpus/memoryMb/diskGb for an ASG, preferring spec overrides and
+    /// falling back to the BinaryLane size catalog.
+    async fn asg_size_info(&self, spec: &AutoScalingGroupSpec) -> Result<(i32, i32, i32), Status> {
+        if let (Some(v), Some(m), Some(d)) = (spec.vcpus, spec.memory_mb, spec.disk_gb) {
+            return Ok((v, m, d));
+        }
+        let sizes = self.get_sizes().await?;
+        let size = sizes
+            .iter()
+            .find(|s| s.slug == spec.size)
+            .ok_or_else(|| Status::not_found(format!("BinaryLane size {} not found", spec.size)))?;
+        Ok((
+            spec.vcpus.unwrap_or(size.vcpus),
+            spec.memory_mb.unwrap_or(size.memory),
+            spec.disk_gb.unwrap_or(size.disk),
+        ))
+    }
+
+    async fn emit_asg_warning(&self, asg: &AutoScalingGroup, reason: &str, message: &str) {
+        let Some(asg_name) = asg.metadata.name.as_deref() else {
+            return;
+        };
+        let now = K8sTime(k8s_openapi::chrono::Utc::now());
+        let event = K8sEvent {
+            metadata: K8sObjectMeta {
+                generate_name: Some("binarylane-autoscaler-".to_string()),
+                namespace: Some(self.secret_namespace.clone()),
+                ..Default::default()
+            },
+            involved_object: K8sObjectReference {
+                api_version: Some("blc.samcday.com/v1alpha1".to_string()),
+                kind: Some("AutoScalingGroup".to_string()),
+                name: Some(asg_name.to_string()),
+                uid: asg.metadata.uid.clone(),
+                ..Default::default()
+            },
+            reason: Some(reason.to_string()),
+            message: Some(message.to_string()),
+            type_: Some("Warning".to_string()),
+            source: Some(K8sEventSource {
+                component: Some("binarylane-autoscaler".to_string()),
+                ..Default::default()
+            }),
+            first_timestamp: Some(now.clone()),
+            last_timestamp: Some(now),
+            count: Some(1),
+            action: Some("Scale".to_string()),
+            ..Default::default()
+        };
+        let events_api: Api<K8sEvent> = Api::namespaced(self.k8s.clone(), &self.secret_namespace);
+        if let Err(e) = events_api.create(&Default::default(), &event).await {
+            warn!(asg = %asg_name, error = %e, reason, "failed to emit ASG event");
+        }
     }
 
     async fn read_secret_value(
@@ -464,22 +596,66 @@ impl proto::cloud_provider_server::CloudProvider for Provider {
         }
 
         let password = self.ensure_password(&asg).await?;
-        let user_data = if let Some(secret_ref) = &asg.spec.user_data_secret_ref {
-            Some(self.read_secret_value(secret_ref, "user-data").await?)
-        } else {
-            None
-        };
+
+        // Resolve template inputs once per RPC — values are shared across all
+        // nodes created in this scale-up. If the template uses any asg.vcpus /
+        // asg.memoryMb / asg.diskGb variables, we need the numbers even when
+        // the user didn't set explicit overrides.
+        let (vcpus, memory_mb, disk_gb) = self.asg_size_info(&asg.spec).await?;
+        let user_vars = user_data::resolve_variables(
+            &self.k8s,
+            &self.secret_namespace,
+            &asg.spec.template_variables,
+        )
+        .await
+        .map_err(Status::from)?;
+
+        let NodeAttrs {
+            labels: base_labels,
+            annotations,
+            taints: base_taints,
+            dropped,
+        } = Self::build_node_labels_and_taints(&asg_name, &asg.spec);
+        if !dropped.is_empty() {
+            let msg = format!(
+                "dropped reserved keys from spec.template: {}",
+                dropped.join(", ")
+            );
+            warn!(asg = %asg_name, dropped = ?dropped, "reserved keys dropped from spec.template");
+            self.emit_asg_warning(&asg, "ReservedKeyDropped", &msg)
+                .await;
+        }
 
         let node_api: Api<K8sNode> = Api::all(self.k8s.clone());
         for i in 0..req.delta {
             let ts = chrono_like_timestamp();
             let name = format!("{}{}-{ts}-{i}", asg.spec.name_prefix, asg_name);
 
-            if let Some(user_data) = &user_data {
+            if let Some(template) = asg.spec.user_data.as_deref() {
+                let builtins = BuiltinVars {
+                    node: NodeVars {
+                        name: name.clone(),
+                        hostname: name.clone(),
+                        index: i,
+                        password: password.clone(),
+                    },
+                    asg: AsgVars {
+                        name: asg_name.clone(),
+                        size: asg.spec.size.clone(),
+                        region: asg.spec.region.clone(),
+                        image: asg.spec.image.clone(),
+                        name_prefix: asg.spec.name_prefix.clone(),
+                        vcpus: Some(vcpus),
+                        memory_mb: Some(memory_mb),
+                        disk_gb: Some(disk_gb),
+                    },
+                };
+                let rendered =
+                    user_data::render(template, &builtins, &user_vars).map_err(Status::from)?;
                 self.create_secret(
                     &controllers::user_data_secret_name(&name),
                     "user-data",
-                    user_data,
+                    &rendered,
                 )
                 .await?;
             }
@@ -491,29 +667,33 @@ impl proto::cloud_provider_server::CloudProvider for Provider {
             )
             .await?;
 
-            let mut labels = self.node_labels(&asg_name, &asg.spec);
+            let mut labels = base_labels.clone();
             labels.insert("kubernetes.io/hostname".to_string(), name.clone());
-            labels.insert(controllers::LABEL_SIZE.to_string(), asg.spec.size.clone());
-            labels.insert(
-                controllers::LABEL_REGION.to_string(),
-                asg.spec.region.clone(),
-            );
-            labels.insert(controllers::LABEL_IMAGE.to_string(), asg.spec.image.clone());
+
+            let taints = base_taints
+                .iter()
+                .map(|t| K8sTaint {
+                    key: t.key.clone(),
+                    value: t.value.clone(),
+                    effect: t.effect.clone(),
+                    ..Default::default()
+                })
+                .collect();
 
             let node = K8sNode {
                 metadata: K8sObjectMeta {
                     name: Some(name.clone()),
                     labels: Some(labels),
+                    annotations: if annotations.is_empty() {
+                        None
+                    } else {
+                        Some(annotations.clone())
+                    },
                     finalizers: Some(vec![controllers::FINALIZER.to_string()]),
                     ..Default::default()
                 },
                 spec: Some(K8sNodeSpec {
-                    taints: Some(vec![K8sTaint {
-                        key: controllers::UNINITIALIZED_TAINT.to_string(),
-                        value: Some("true".to_string()),
-                        effect: "NoSchedule".to_string(),
-                        ..Default::default()
-                    }]),
+                    taints: Some(taints),
                     ..Default::default()
                 }),
                 status: None,
@@ -658,7 +838,12 @@ impl proto::cloud_provider_server::CloudProvider for Provider {
             .or_else(|| size_info.as_ref().map(|s| s.disk))
             .ok_or_else(|| Status::internal("missing disk for template node info".to_string()))?;
 
-        let mut labels = self.node_labels(&asg_name, &asg.spec);
+        let NodeAttrs {
+            mut labels,
+            annotations,
+            taints: taint_tuples,
+            dropped: _,
+        } = Self::build_node_labels_and_taints(&asg_name, &asg.spec);
         labels.insert(
             "kubernetes.io/hostname".to_string(),
             format!("template-{asg_name}"),
@@ -716,20 +901,30 @@ impl proto::cloud_provider_server::CloudProvider for Provider {
             },
         );
 
+        let pb_taints: Vec<Taint> = taint_tuples
+            .into_iter()
+            .map(|t| Taint {
+                key: Some(t.key),
+                value: t.value,
+                effect: Some(t.effect),
+                ..Default::default()
+            })
+            .collect();
+
         let node = Node {
             metadata: Some(ObjectMeta {
                 name: Some(format!("template-{asg_name}")),
                 labels,
+                annotations: if annotations.is_empty() {
+                    Default::default()
+                } else {
+                    annotations
+                },
                 ..Default::default()
             }),
             spec: Some(NodeSpec {
                 provider_id: Some(format!("{}:///template", binarylane::PROVIDER_NAME)),
-                taints: vec![Taint {
-                    key: Some("node.cloudprovider.kubernetes.io/uninitialized".to_string()),
-                    value: Some("true".to_string()),
-                    effect: Some("NoSchedule".to_string()),
-                    ..Default::default()
-                }],
+                taints: pb_taints,
                 ..Default::default()
             }),
             status: Some(NodeStatus {
@@ -765,4 +960,183 @@ fn chrono_like_timestamp() -> String {
         .unwrap_or_default();
     // Millisecond granularity avoids name collisions from rapid successive calls
     format!("{}", dur.as_millis())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use binarylane_controller::crd::{NodeTaint, NodeTemplate, NodeTemplateMeta, NodeTemplateSpec};
+
+    fn base_spec() -> AutoScalingGroupSpec {
+        AutoScalingGroupSpec {
+            min_size: 0,
+            max_size: 5,
+            size: "std-2".into(),
+            region: "syd".into(),
+            image: "ubuntu-22.04".into(),
+            vcpus: None,
+            memory_mb: None,
+            disk_gb: None,
+            name_prefix: String::new(),
+            password_secret_ref: None,
+            user_data: None,
+            template_variables: Vec::new(),
+            template: None,
+        }
+    }
+
+    #[test]
+    fn controller_labels_and_taints_default() {
+        let attrs = Provider::build_node_labels_and_taints("workers", &base_spec());
+        assert_eq!(
+            attrs.labels.get(controllers::LABEL_ASG).map(String::as_str),
+            Some("workers"),
+        );
+        assert_eq!(
+            attrs
+                .labels
+                .get(controllers::LABEL_SIZE)
+                .map(String::as_str),
+            Some("std-2"),
+        );
+        assert_eq!(
+            attrs
+                .labels
+                .get(controllers::LABEL_REGION)
+                .map(String::as_str),
+            Some("syd"),
+        );
+        assert_eq!(
+            attrs
+                .labels
+                .get(controllers::LABEL_IMAGE)
+                .map(String::as_str),
+            Some("ubuntu-22.04"),
+        );
+        assert_eq!(
+            attrs.labels.get("kubernetes.io/arch").map(String::as_str),
+            Some("amd64"),
+        );
+        assert_eq!(attrs.taints.len(), 1);
+        assert_eq!(attrs.taints[0].key, controllers::UNINITIALIZED_TAINT);
+        assert!(attrs.annotations.is_empty());
+        assert!(attrs.dropped.is_empty());
+    }
+
+    #[test]
+    fn user_labels_annotations_taints_merged() {
+        let mut user_labels = BTreeMap::new();
+        user_labels.insert("role".into(), "gpu-worker".into());
+        let mut user_annotations = BTreeMap::new();
+        user_annotations.insert("company.io/team".into(), "infra".into());
+
+        let mut spec = base_spec();
+        spec.template = Some(NodeTemplate {
+            metadata: Some(NodeTemplateMeta {
+                labels: Some(user_labels),
+                annotations: Some(user_annotations),
+            }),
+            spec: Some(NodeTemplateSpec {
+                taints: Some(vec![NodeTaint {
+                    key: "gpu".into(),
+                    value: Some("true".into()),
+                    effect: "NoSchedule".into(),
+                }]),
+            }),
+        });
+
+        let attrs = Provider::build_node_labels_and_taints("workers", &spec);
+        assert_eq!(
+            attrs.labels.get("role").map(String::as_str),
+            Some("gpu-worker")
+        );
+        assert_eq!(
+            attrs.annotations.get("company.io/team").map(String::as_str),
+            Some("infra"),
+        );
+        assert_eq!(attrs.taints.len(), 2);
+        assert!(attrs.taints.iter().any(|t| t.key == "gpu"));
+        assert!(attrs.dropped.is_empty());
+    }
+
+    #[test]
+    fn reserved_label_collision_dropped() {
+        let mut user_labels = BTreeMap::new();
+        user_labels.insert("kubernetes.io/hostname".into(), "pwned".into());
+        user_labels.insert(controllers::LABEL_SIZE.into(), "tampered".into());
+        user_labels.insert("role".into(), "kept".into());
+
+        let mut spec = base_spec();
+        spec.template = Some(NodeTemplate {
+            metadata: Some(NodeTemplateMeta {
+                labels: Some(user_labels),
+                annotations: None,
+            }),
+            spec: None,
+        });
+
+        let attrs = Provider::build_node_labels_and_taints("workers", &spec);
+        // Controller value preserved
+        assert_eq!(
+            attrs
+                .labels
+                .get(controllers::LABEL_SIZE)
+                .map(String::as_str),
+            Some("std-2"),
+        );
+        // Non-reserved key still makes it through
+        assert_eq!(attrs.labels.get("role").map(String::as_str), Some("kept"));
+        // Dropped list mentions both reserved keys
+        assert!(
+            attrs
+                .dropped
+                .iter()
+                .any(|d| d == "label:kubernetes.io/hostname")
+        );
+        assert!(
+            attrs
+                .dropped
+                .iter()
+                .any(|d| *d == format!("label:{}", controllers::LABEL_SIZE)),
+        );
+    }
+
+    #[test]
+    fn reserved_taint_collision_dropped() {
+        let mut spec = base_spec();
+        spec.template = Some(NodeTemplate {
+            metadata: None,
+            spec: Some(NodeTemplateSpec {
+                taints: Some(vec![
+                    NodeTaint {
+                        key: controllers::UNINITIALIZED_TAINT.into(),
+                        value: Some("no".into()),
+                        effect: "NoSchedule".into(),
+                    },
+                    NodeTaint {
+                        key: "gpu".into(),
+                        value: Some("true".into()),
+                        effect: "NoSchedule".into(),
+                    },
+                ]),
+            }),
+        });
+
+        let attrs = Provider::build_node_labels_and_taints("workers", &spec);
+        // Only the default uninitialized taint plus the user's gpu taint remain
+        assert_eq!(attrs.taints.len(), 2);
+        let uninit = attrs
+            .taints
+            .iter()
+            .find(|t| t.key == controllers::UNINITIALIZED_TAINT)
+            .unwrap();
+        // User override was dropped; value stays "true" (our controller value)
+        assert_eq!(uninit.value.as_deref(), Some("true"));
+        assert!(
+            attrs
+                .dropped
+                .iter()
+                .any(|d| d == &format!("taint:{}", controllers::UNINITIALIZED_TAINT)),
+        );
+    }
 }

--- a/src/controllers/mod.rs
+++ b/src/controllers/mod.rs
@@ -28,8 +28,15 @@ pub const ANNOTATION_ADOPT: &str = "bl.samcday.com/adopt";
 
 /// Labels set by the controller on every provisioned Node. User values from
 /// `spec.template.metadata.labels` that collide with these keys are dropped.
+///
+/// `LABEL_SERVER_ID` is reserved even though the autoscaler doesn't set it at
+/// Node creation — it's written by `node_provision` once the BinaryLane server
+/// is created, and `node_provision::reconcile` treats its presence as "already
+/// provisioned" and skips server creation entirely. A user-supplied value here
+/// would leave the Node permanently uninitialized.
 pub const RESERVED_LABELS: &[&str] = &[
     LABEL_ASG,
+    LABEL_SERVER_ID,
     LABEL_SIZE,
     LABEL_REGION,
     LABEL_IMAGE,

--- a/src/controllers/mod.rs
+++ b/src/controllers/mod.rs
@@ -17,6 +17,7 @@ pub const FINALIZER: &str = "blc.samcday.com/server-cleanup";
 pub const UNINITIALIZED_TAINT: &str = "node.cloudprovider.kubernetes.io/uninitialized";
 
 // Labels
+pub const LABEL_ASG: &str = "blc.samcday.com/asg";
 pub const LABEL_SERVER_ID: &str = "bl.samcday.com/server-id";
 pub const LABEL_SIZE: &str = "bl.samcday.com/size";
 pub const LABEL_REGION: &str = "bl.samcday.com/region";
@@ -24,6 +25,25 @@ pub const LABEL_IMAGE: &str = "bl.samcday.com/image";
 
 // Annotations
 pub const ANNOTATION_ADOPT: &str = "bl.samcday.com/adopt";
+
+/// Labels set by the controller on every provisioned Node. User values from
+/// `spec.template.metadata.labels` that collide with these keys are dropped.
+pub const RESERVED_LABELS: &[&str] = &[
+    LABEL_ASG,
+    LABEL_SIZE,
+    LABEL_REGION,
+    LABEL_IMAGE,
+    "kubernetes.io/hostname",
+    "kubernetes.io/arch",
+    "kubernetes.io/os",
+    "node.kubernetes.io/instance-type",
+    "node.kubernetes.io/cloud-provider",
+    "topology.kubernetes.io/region",
+];
+
+/// Taint keys set by the controller on every provisioned Node. User taints
+/// from `spec.template.spec.taints` whose key matches are dropped.
+pub const RESERVED_TAINT_KEYS: &[&str] = &[UNINITIALIZED_TAINT];
 
 pub fn node_password_secret_name(node_name: &str) -> String {
     format!("{node_name}-node-password")

--- a/src/crd.rs
+++ b/src/crd.rs
@@ -1,6 +1,7 @@
 use kube::CustomResource;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 
 #[derive(CustomResource, JsonSchema, Deserialize, Serialize, Clone, Debug)]
 #[kube(
@@ -42,13 +43,29 @@ pub struct AutoScalingGroupSpec {
     /// Node name prefix. Nodes named {namePrefix}{asgName}-{ts}-{idx}
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub name_prefix: String,
-    /// Reference to a Secret containing user-data for provisioned nodes
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub user_data_secret_ref: Option<SecretRef>,
     /// Reference to a Secret containing a shared password for all nodes.
     /// If omitted, a password is auto-generated into {asgName}-password.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub password_secret_ref: Option<SecretRef>,
+    /// Cloud-init user-data template (MiniJinja). Rendered per-node at scale-up.
+    /// Built-in variables: `node.name`, `node.index`, `node.password`,
+    /// `asg.name`, `asg.size`, `asg.region`, `asg.image`, `asg.namePrefix`,
+    /// `asg.vcpus`, `asg.memoryMb`, `asg.diskGb`.
+    /// User variables from `templateVariables` are available at the top level.
+    /// Templating is evaluated at scale-up time only; Secret/ConfigMap changes
+    /// do not re-render previously provisioned nodes.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user_data: Option<String>,
+    /// Variables injected into the `userData` template, in addition to the
+    /// built-in `node.*` and `asg.*` scopes.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub template_variables: Vec<TemplateVariable>,
+    /// Template applied to Nodes produced by this ASG. Labels/annotations/
+    /// taints defined here are merged with controller-owned values at
+    /// scale-up time; user values that collide with reserved keys are
+    /// dropped and reported as a Warning Event on the ASG.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub template: Option<NodeTemplate>,
 }
 
 #[derive(JsonSchema, Deserialize, Serialize, Clone, Debug, Default)]
@@ -61,6 +78,74 @@ pub struct SecretRef {
     /// Key within the Secret. Defaults to "user-data" or "password" depending on context.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub key: Option<String>,
+}
+
+#[derive(JsonSchema, Deserialize, Serialize, Clone, Debug, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct NodeTemplate {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<NodeTemplateMeta>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub spec: Option<NodeTemplateSpec>,
+}
+
+#[derive(JsonSchema, Deserialize, Serialize, Clone, Debug, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct NodeTemplateMeta {
+    /// Additional labels to apply to provisioned Nodes. Values that collide
+    /// with controller-owned labels are dropped.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub labels: Option<BTreeMap<String, String>>,
+    /// Annotations to apply to provisioned Nodes.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub annotations: Option<BTreeMap<String, String>>,
+}
+
+#[derive(JsonSchema, Deserialize, Serialize, Clone, Debug, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct NodeTemplateSpec {
+    /// Additional taints to apply to provisioned Nodes. Entries whose key
+    /// collides with controller-owned taints are dropped.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub taints: Option<Vec<NodeTaint>>,
+}
+
+#[derive(JsonSchema, Deserialize, Serialize, Clone, Debug)]
+pub struct NodeTaint {
+    pub key: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value: Option<String>,
+    /// One of: NoSchedule, PreferNoSchedule, NoExecute.
+    pub effect: String,
+}
+
+#[derive(JsonSchema, Deserialize, Serialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct TemplateVariable {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value_from: Option<TemplateVariableSource>,
+}
+
+#[derive(JsonSchema, Deserialize, Serialize, Clone, Debug, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct TemplateVariableSource {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub secret_key_ref: Option<KeySelector>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub config_map_key_ref: Option<KeySelector>,
+}
+
+#[derive(JsonSchema, Deserialize, Serialize, Clone, Debug, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct KeySelector {
+    pub name: String,
+    /// Namespace of the resource. Defaults to the controller's namespace.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub namespace: Option<String>,
+    pub key: String,
 }
 
 #[derive(JsonSchema, Deserialize, Serialize, Clone, Debug, Default)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod crd;
+pub mod user_data;

--- a/src/user_data.rs
+++ b/src/user_data.rs
@@ -1,0 +1,385 @@
+use std::collections::BTreeMap;
+
+use k8s_openapi::api::core::v1::{ConfigMap, Secret};
+use kube::Api;
+use minijinja::{Environment, UndefinedBehavior, Value};
+use serde::Serialize;
+use tonic::Status;
+
+use crate::crd::{TemplateVariable, TemplateVariableSource};
+
+#[derive(Debug, thiserror::Error)]
+pub enum RenderError {
+    #[error("template variable '{0}' collides with built-in scope (node/asg)")]
+    ReservedName(String),
+    #[error("template variable '{0}' has neither value nor valueFrom")]
+    MissingSource(String),
+    #[error("template variable '{0}' sets both value and valueFrom")]
+    AmbiguousSource(String),
+    #[error("template variable '{0}' valueFrom sets both secretKeyRef and configMapKeyRef")]
+    AmbiguousValueFrom(String),
+    #[error("template variable '{0}' valueFrom sets neither secretKeyRef nor configMapKeyRef")]
+    EmptyValueFrom(String),
+    #[error("secret {ns}/{name} not found")]
+    SecretNotFound { ns: String, name: String },
+    #[error("secret {ns}/{name} missing key '{key}'")]
+    SecretMissingKey {
+        ns: String,
+        name: String,
+        key: String,
+    },
+    #[error("secret {ns}/{name} key '{key}' is not valid UTF-8")]
+    SecretNotUtf8 {
+        ns: String,
+        name: String,
+        key: String,
+    },
+    #[error("configmap {ns}/{name} not found")]
+    ConfigMapNotFound { ns: String, name: String },
+    #[error("configmap {ns}/{name} missing key '{key}'")]
+    ConfigMapMissingKey {
+        ns: String,
+        name: String,
+        key: String,
+    },
+    #[error("kube API error: {0}")]
+    Kube(#[from] kube::Error),
+    #[error("template error: {0}")]
+    Template(String),
+}
+
+impl From<RenderError> for Status {
+    fn from(e: RenderError) -> Self {
+        use RenderError::*;
+        match &e {
+            ReservedName(_)
+            | AmbiguousSource(_)
+            | MissingSource(_)
+            | AmbiguousValueFrom(_)
+            | EmptyValueFrom(_) => Status::invalid_argument(e.to_string()),
+            SecretNotFound { .. } | ConfigMapNotFound { .. } => Status::not_found(e.to_string()),
+            SecretMissingKey { .. } | ConfigMapMissingKey { .. } | SecretNotUtf8 { .. } => {
+                Status::failed_precondition(e.to_string())
+            }
+            Template(_) => Status::failed_precondition(e.to_string()),
+            Kube(_) => Status::internal(e.to_string()),
+        }
+    }
+}
+
+#[derive(Serialize, Debug, Clone)]
+pub struct NodeVars {
+    pub name: String,
+    pub hostname: String,
+    pub index: i32,
+    pub password: String,
+}
+
+#[derive(Serialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct AsgVars {
+    pub name: String,
+    pub size: String,
+    pub region: String,
+    pub image: String,
+    pub name_prefix: String,
+    pub vcpus: Option<i32>,
+    pub memory_mb: Option<i32>,
+    pub disk_gb: Option<i32>,
+}
+
+pub struct BuiltinVars {
+    pub node: NodeVars,
+    pub asg: AsgVars,
+}
+
+/// Validate variable names without touching the cluster. Run this before any
+/// API call so we fail fast on user errors.
+fn validate_variables(vars: &[TemplateVariable]) -> Result<(), RenderError> {
+    for v in vars {
+        if v.name == "node" || v.name == "asg" {
+            return Err(RenderError::ReservedName(v.name.clone()));
+        }
+        match (&v.value, &v.value_from) {
+            (Some(_), Some(_)) => return Err(RenderError::AmbiguousSource(v.name.clone())),
+            (None, None) => return Err(RenderError::MissingSource(v.name.clone())),
+            (None, Some(src)) => match (&src.secret_key_ref, &src.config_map_key_ref) {
+                (Some(_), Some(_)) => {
+                    return Err(RenderError::AmbiguousValueFrom(v.name.clone()));
+                }
+                (None, None) => return Err(RenderError::EmptyValueFrom(v.name.clone())),
+                _ => {}
+            },
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+/// Resolve every `TemplateVariable` to a concrete string, reading Secrets and
+/// ConfigMaps as needed. Called once per scale-up; values are static for all
+/// nodes created in the same increase-size RPC.
+pub async fn resolve_variables(
+    k8s: &kube::Client,
+    default_ns: &str,
+    vars: &[TemplateVariable],
+) -> Result<BTreeMap<String, String>, RenderError> {
+    validate_variables(vars)?;
+    let mut out = BTreeMap::new();
+    for v in vars {
+        let value = if let Some(lit) = &v.value {
+            lit.clone()
+        } else {
+            // Safe: validate_variables ensured exactly one of secretKeyRef /
+            // configMapKeyRef is set.
+            resolve_source(k8s, default_ns, v.value_from.as_ref().unwrap()).await?
+        };
+        out.insert(v.name.clone(), value);
+    }
+    Ok(out)
+}
+
+async fn resolve_source(
+    k8s: &kube::Client,
+    default_ns: &str,
+    src: &TemplateVariableSource,
+) -> Result<String, RenderError> {
+    if let Some(sel) = &src.secret_key_ref {
+        let ns = sel.namespace.as_deref().unwrap_or(default_ns);
+        let api: Api<Secret> = Api::namespaced(k8s.clone(), ns);
+        let secret = api
+            .get_opt(&sel.name)
+            .await?
+            .ok_or_else(|| RenderError::SecretNotFound {
+                ns: ns.to_string(),
+                name: sel.name.clone(),
+            })?;
+        let data = secret.data.ok_or_else(|| RenderError::SecretMissingKey {
+            ns: ns.to_string(),
+            name: sel.name.clone(),
+            key: sel.key.clone(),
+        })?;
+        let bytes = data
+            .get(&sel.key)
+            .ok_or_else(|| RenderError::SecretMissingKey {
+                ns: ns.to_string(),
+                name: sel.name.clone(),
+                key: sel.key.clone(),
+            })?;
+        return String::from_utf8(bytes.0.clone()).map_err(|_| RenderError::SecretNotUtf8 {
+            ns: ns.to_string(),
+            name: sel.name.clone(),
+            key: sel.key.clone(),
+        });
+    }
+    let sel = src
+        .config_map_key_ref
+        .as_ref()
+        .expect("validate_variables guarantees configMapKeyRef is set when secretKeyRef is absent");
+    let ns = sel.namespace.as_deref().unwrap_or(default_ns);
+    let api: Api<ConfigMap> = Api::namespaced(k8s.clone(), ns);
+    let cm = api
+        .get_opt(&sel.name)
+        .await?
+        .ok_or_else(|| RenderError::ConfigMapNotFound {
+            ns: ns.to_string(),
+            name: sel.name.clone(),
+        })?;
+    let data = cm.data.ok_or_else(|| RenderError::ConfigMapMissingKey {
+        ns: ns.to_string(),
+        name: sel.name.clone(),
+        key: sel.key.clone(),
+    })?;
+    data.get(&sel.key)
+        .cloned()
+        .ok_or_else(|| RenderError::ConfigMapMissingKey {
+            ns: ns.to_string(),
+            name: sel.name.clone(),
+            key: sel.key.clone(),
+        })
+}
+
+pub fn render(
+    template: &str,
+    builtins: &BuiltinVars,
+    user_vars: &BTreeMap<String, String>,
+) -> Result<String, RenderError> {
+    let mut env = Environment::new();
+    env.set_undefined_behavior(UndefinedBehavior::Strict);
+
+    let mut ctx: BTreeMap<String, Value> = BTreeMap::new();
+    ctx.insert("node".into(), Value::from_serialize(&builtins.node));
+    ctx.insert("asg".into(), Value::from_serialize(&builtins.asg));
+    for (k, v) in user_vars {
+        if k == "node" || k == "asg" {
+            return Err(RenderError::ReservedName(k.clone()));
+        }
+        ctx.insert(k.clone(), Value::from(v.clone()));
+    }
+    env.render_str(template, ctx)
+        .map_err(|e| RenderError::Template(format!("{e:#}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::crd::{KeySelector, TemplateVariable, TemplateVariableSource};
+
+    fn sample_builtins() -> BuiltinVars {
+        BuiltinVars {
+            node: NodeVars {
+                name: "worker-1".into(),
+                hostname: "worker-1".into(),
+                index: 0,
+                password: "supersecret".into(),
+            },
+            asg: AsgVars {
+                name: "workers".into(),
+                size: "std-2".into(),
+                region: "syd".into(),
+                image: "ubuntu-22.04".into(),
+                name_prefix: "".into(),
+                vcpus: Some(2),
+                memory_mb: Some(4096),
+                disk_gb: Some(40),
+            },
+        }
+    }
+
+    #[test]
+    fn render_builtins() {
+        let out = render(
+            "name={{ node.name }} region={{ asg.region }} mem={{ asg.memoryMb }}",
+            &sample_builtins(),
+            &BTreeMap::new(),
+        )
+        .unwrap();
+        assert_eq!(out, "name=worker-1 region=syd mem=4096");
+    }
+
+    #[test]
+    fn render_user_var() {
+        let mut vars = BTreeMap::new();
+        vars.insert("joinToken".to_string(), "abc.def".to_string());
+        let out = render(
+            "{{ joinToken }} on {{ node.name }}",
+            &sample_builtins(),
+            &vars,
+        )
+        .unwrap();
+        assert_eq!(out, "abc.def on worker-1");
+    }
+
+    #[test]
+    fn undefined_is_strict() {
+        let err = render("{{ mystery }}", &sample_builtins(), &BTreeMap::new()).unwrap_err();
+        assert!(matches!(err, RenderError::Template(_)));
+    }
+
+    #[test]
+    fn user_var_cannot_shadow_scopes() {
+        let mut vars = BTreeMap::new();
+        vars.insert("node".to_string(), "bad".to_string());
+        let err = render("{{ node }}", &sample_builtins(), &vars).unwrap_err();
+        assert!(matches!(err, RenderError::ReservedName(_)));
+    }
+
+    #[test]
+    fn syntax_error_surfaces() {
+        let err = render("{{ unclosed", &sample_builtins(), &BTreeMap::new()).unwrap_err();
+        assert!(matches!(err, RenderError::Template(_)));
+    }
+
+    #[test]
+    fn validate_literal_ok() {
+        let vars = vec![TemplateVariable {
+            name: "foo".into(),
+            value: Some("bar".into()),
+            value_from: None,
+        }];
+        validate_variables(&vars).unwrap();
+    }
+
+    #[test]
+    fn validate_reserved_name() {
+        let vars = vec![TemplateVariable {
+            name: "node".into(),
+            value: Some("x".into()),
+            value_from: None,
+        }];
+        assert!(matches!(
+            validate_variables(&vars),
+            Err(RenderError::ReservedName(_))
+        ));
+    }
+
+    #[test]
+    fn validate_missing_source() {
+        let vars = vec![TemplateVariable {
+            name: "foo".into(),
+            value: None,
+            value_from: None,
+        }];
+        assert!(matches!(
+            validate_variables(&vars),
+            Err(RenderError::MissingSource(_))
+        ));
+    }
+
+    #[test]
+    fn validate_ambiguous_source() {
+        let vars = vec![TemplateVariable {
+            name: "joinToken".into(),
+            value: Some("lit".into()),
+            value_from: Some(TemplateVariableSource {
+                secret_key_ref: Some(KeySelector {
+                    name: "s".into(),
+                    namespace: None,
+                    key: "k".into(),
+                }),
+                config_map_key_ref: None,
+            }),
+        }];
+        assert!(matches!(
+            validate_variables(&vars),
+            Err(RenderError::AmbiguousSource(_))
+        ));
+    }
+
+    #[test]
+    fn validate_ambiguous_value_from() {
+        let vars = vec![TemplateVariable {
+            name: "foo".into(),
+            value: None,
+            value_from: Some(TemplateVariableSource {
+                secret_key_ref: Some(KeySelector {
+                    name: "s".into(),
+                    namespace: None,
+                    key: "k".into(),
+                }),
+                config_map_key_ref: Some(KeySelector {
+                    name: "c".into(),
+                    namespace: None,
+                    key: "k".into(),
+                }),
+            }),
+        }];
+        assert!(matches!(
+            validate_variables(&vars),
+            Err(RenderError::AmbiguousValueFrom(_))
+        ));
+    }
+
+    #[test]
+    fn validate_empty_value_from() {
+        let vars = vec![TemplateVariable {
+            name: "foo".into(),
+            value: None,
+            value_from: Some(TemplateVariableSource::default()),
+        }];
+        assert!(matches!(
+            validate_variables(&vars),
+            Err(RenderError::EmptyValueFrom(_))
+        ));
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1865,24 +1865,20 @@ fn write_dev_resources(
 ) -> Result<()> {
     ensure_parent_dir(resources_path)?;
 
-    let cloud_init_template =
+    let cloud_init =
         fs::read_to_string("dev-cloud-init.sh").context("reading dev-cloud-init.sh")?;
-    let cloud_init = cloud_init_template
-        .replace("{{.K3S_URL}}", k3s_url)
-        .replace("{{.K3S_TOKEN}}", k3s_token)
-        .replace("{{.NodeName}}", "$(hostname)")
-        .replace("{{.NodeGroup}}", DEV_AUTOSCALER_GROUP_ID);
 
     let contents = format!(
         r#"apiVersion: v1
 kind: Secret
 metadata:
-  name: dev-cloud-init
+  name: dev-k3s-join
   namespace: default
 type: Opaque
 stringData:
-  user-data: |
-{cloud_init}---
+  url: "{k3s_url}"
+  token: "{k3s_token}"
+---
 apiVersion: blc.samcday.com/v1alpha1
 kind: AutoScalingGroup
 metadata:
@@ -1894,10 +1890,21 @@ spec:
   region: "{region}"
   image: "{image}"
   namePrefix: "{cluster_name}-"
-  userDataSecretRef:
-    name: dev-cloud-init
-    namespace: default
-    key: user-data
+  userData: |
+{cloud_init}
+  templateVariables:
+    - name: k3sUrl
+      valueFrom:
+        secretKeyRef:
+          name: dev-k3s-join
+          namespace: default
+          key: url
+    - name: k3sToken
+      valueFrom:
+        secretKeyRef:
+          name: dev-k3s-join
+          namespace: default
+          key: token
 "#,
         cloud_init = indent_block(&cloud_init, 4),
         group_id = DEV_AUTOSCALER_GROUP_ID,
@@ -1905,6 +1912,8 @@ spec:
         region = yaml_escape(&args.region),
         image = yaml_escape(&args.image),
         cluster_name = cluster_name,
+        k3s_url = yaml_escape(k3s_url),
+        k3s_token = yaml_escape(k3s_token),
     );
 
     fs::write(resources_path, contents)


### PR DESCRIPTION
Replace `spec.userDataSecretRef` with `spec.userData` (a MiniJinja template rendered per-node at scale-up) and `spec.templateVariables` (EnvVar-style with literal / Secret / ConfigMap sources). Add `spec.template` in Pod-template shape so users can declare labels, annotations, and taints for every Node produced by the ASG; merged values flow through both real Node creation and the cluster-autoscaler `NodeGroupTemplateNodeInfo` simulator, with controller-owned keys taking precedence and dropped user overrides surfaced as a Warning Event on the ASG.